### PR TITLE
feat: add step function capabilities to the tracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,32 @@ exports.handler = lumigo.trace(myHandler)
 Note that if you do specify a domains list - the default list will be overridden.
 * In case of need, there is a kill switch, that stops all the interventions of lumigo immediately, without changing the code. Simply add an environment variable `LUMIGO_SWITCH_OFF=TRUE`.
 
+### Step Functions
+If this function is part of a step function, you can add the flag `step_function` or environment variable `LUMIGO_STEP_FUNCTION=True`, and we will track the states in the step function as a single transaction.
+```
+const lumigo = require('@lumigo/tracer')({ token: 'DEADBEEF', step_function: true })
+```
+Note: we will add the key `"_lumigo"` to the return value of the function. 
+
+If you override the `"Parameters"` configuration, simply add `"_lumigo.$": "$._lumigo"`. <br/>
+For example:
+```
+"States": {
+    "state1": {
+      "Type": "Task",
+      "Resource": "arn:aws:lambda:us-west-2:ACCOUNT:function:FUNCTION_NAME",
+      "Parameters": {
+          "Changed": "parameters",
+          "_lumigo.$": "$._lumigo"
+        },
+      "Next": "state2"
+    },
+    "state2": {
+      "Type": "pass",
+      "End": true
+    }
+}
+```
 
 ## Logging Programmatic Errors
 In order to log custom errors which will be visible in the platform, you can use `console.log("[LUMIGO_LOG] <YOUR_MESSAGE>");` from anywhere in your lambda code.

--- a/src/events.js
+++ b/src/events.js
@@ -1,7 +1,8 @@
 import {
   isStepFunction,
-  getLumigoEventKey,
+  recursiveGetKey,
   STEP_FUNCTION_UID_KEY,
+  LUMIGO_EVENT_KEY,
 } from './utils';
 
 export const getTriggeredBy = event => {
@@ -22,7 +23,7 @@ export const getTriggeredBy = event => {
     return 'apigw';
   }
 
-  if (isStepFunction() && event && !!getLumigoEventKey(event)) {
+  if (isStepFunction() && event && !!recursiveGetKey(event, LUMIGO_EVENT_KEY)) {
     return 'stepFunction';
   }
 
@@ -65,7 +66,11 @@ export const getRelevantEventData = (triggeredBy, event) => {
     case 'apigw':
       return getApiGatewayData(event);
     case 'stepFunction':
-      return { messageId: getLumigoEventKey(event)[STEP_FUNCTION_UID_KEY] };
+      return {
+        messageId: recursiveGetKey(event, LUMIGO_EVENT_KEY)[
+          STEP_FUNCTION_UID_KEY
+        ],
+      };
     case 'invocation':
     default:
       return {};

--- a/src/events.js
+++ b/src/events.js
@@ -1,3 +1,9 @@
+import {
+  isStepFunction,
+  getLumigoEventKey,
+  STEP_FUNCTION_UID_KEY,
+} from './utils';
+
 export const getTriggeredBy = event => {
   if (event && event['Records']) {
     // XXX Parses s3, sns, ses, kinesis, dynamodb event sources.
@@ -14,6 +20,10 @@ export const getTriggeredBy = event => {
 
   if (event && event['httpMethod']) {
     return 'apigw';
+  }
+
+  if (isStepFunction() && event && !!getLumigoEventKey(event)) {
+    return 'stepFunction';
   }
 
   return 'invocation';
@@ -54,6 +64,8 @@ export const getRelevantEventData = (triggeredBy, event) => {
       return { arn: event.Records[0].s3.bucket.arn };
     case 'apigw':
       return getApiGatewayData(event);
+    case 'stepFunction':
+      return { messageId: getLumigoEventKey(event)[STEP_FUNCTION_UID_KEY] };
     case 'invocation':
     default:
       return {};

--- a/src/events.test.js
+++ b/src/events.test.js
@@ -1,3 +1,5 @@
+import * as utils from './utils';
+
 const events = require('./events');
 const exampleS3Event = require('./testdata/events/s3-event.json');
 const exampleSnsEvent = require('./testdata/events/sns-event.json');
@@ -106,6 +108,18 @@ describe('events', () => {
     expect(events.getEventInfo(exampleS3Event)).toEqual({
       arn: 'arn:aws:s3:::mybucket',
       triggeredBy: 's3',
+    });
+
+    jest.spyOn(utils, 'isStepFunction');
+    utils.isStepFunction.mockReturnValueOnce(true);
+    expect(
+      events.getEventInfo({
+        data: 1,
+        [utils.LUMIGO_EVENT_KEY]: { [utils.STEP_FUNCTION_UID_KEY]: '123' },
+      })
+    ).toEqual({
+      triggeredBy: 'stepFunction',
+      messageId: '123',
     });
   });
 });

--- a/src/events.test.js
+++ b/src/events.test.js
@@ -1,4 +1,5 @@
 import * as utils from './utils';
+import { TracerGlobals } from './globals';
 
 const events = require('./events');
 const exampleS3Event = require('./testdata/events/s3-event.json');
@@ -110,8 +111,7 @@ describe('events', () => {
       triggeredBy: 's3',
     });
 
-    jest.spyOn(utils, 'isStepFunction');
-    utils.isStepFunction.mockReturnValueOnce(true);
+    TracerGlobals.setTracerInputs({ stepFunction: true });
     expect(
       events.getEventInfo({
         data: 1,

--- a/src/globals.js
+++ b/src/globals.js
@@ -20,6 +20,7 @@ export const TracerGlobals = (() => {
     debug: false,
     edgeHost: '',
     switchOff: false,
+    isStepFunction: false,
   };
 
   const setHandlerInputs = ({ event, context }) =>
@@ -35,6 +36,7 @@ export const TracerGlobals = (() => {
     debug = false,
     edgeHost = '',
     switchOff = false,
+    stepFunction = false,
   }) =>
     Object.assign(tracerInputs, {
       token: token || process.env.LUMIGO_TRACER_TOKEN,
@@ -51,6 +53,12 @@ export const TracerGlobals = (() => {
           process.env['LUMIGO_SWITCH_OFF'] &&
           process.env.LUMIGO_SWITCH_OFF === 'TRUE'
         ),
+      isStepFunction:
+        stepFunction ||
+        !!(
+          process.env['LUMIGO_STEP_FUNCTION'] &&
+          process.env.LUMIGO_STEP_FUNCTION.toUpperCase() === 'TRUE'
+        ),
     });
 
   const getTracerInputs = () => tracerInputs;
@@ -61,6 +69,7 @@ export const TracerGlobals = (() => {
       debug: false,
       edgeHost: '',
       switchOff: false,
+      isStepFunction: false,
     });
 
   return {

--- a/src/globals.test.js
+++ b/src/globals.test.js
@@ -91,6 +91,19 @@ describe('globals', () => {
     );
   });
 
+  test('setGlobals stepFunction', () => {
+    globals.TracerGlobals.setTracerInputs({ stepFunction: true });
+    expect(globals.TracerGlobals.getTracerInputs().isStepFunction).toBeTruthy();
+
+    process.env.LUMIGO_STEP_FUNCTION = 'True';
+    globals.TracerGlobals.setTracerInputs({});
+    expect(globals.TracerGlobals.getTracerInputs().isStepFunction).toBeTruthy();
+    process.env.LUMIGO_STEP_FUNCTION = undefined;
+
+    globals.TracerGlobals.setTracerInputs({});
+    expect(globals.TracerGlobals.getTracerInputs().isStepFunction).toBeFalsy;
+  });
+
   test('TracerGlobals', () => {
     const event = { a: 'b', c: 'd' };
     const context = { e: 'f', g: 'h' };
@@ -109,17 +122,20 @@ describe('globals', () => {
     const debug = true;
     const token = 'abcdefg';
     const edgeHost = 'zarathustra.com';
+    const isStepFunction = false;
     globals.TracerGlobals.setTracerInputs({
       token,
       debug,
       edgeHost,
       switchOff,
+      isStepFunction,
     });
     expect(globals.TracerGlobals.getTracerInputs()).toEqual({
       token,
       debug,
       edgeHost,
       switchOff,
+      isStepFunction,
     });
     globals.TracerGlobals.clearTracerInputs();
     expect(globals.TracerGlobals.getTracerInputs()).toEqual({
@@ -127,6 +143,7 @@ describe('globals', () => {
       debug: false,
       edgeHost: '',
       switchOff: false,
+      isStepFunction: false,
     });
   });
 
@@ -162,6 +179,7 @@ describe('globals', () => {
       debug: false,
       edgeHost: '',
       switchOff: false,
+      isStepFunction: false,
     });
   });
 });

--- a/src/hooks/http.js
+++ b/src/hooks/http.js
@@ -254,6 +254,17 @@ export const httpGetWrapper = httpModule => (/* originalGetFn */) =>
     return req;
   };
 
+export const addStepFunctionEvent = messageId => {
+  const httpSpan = getHttpSpan({}, {});
+  const stepInfo = Object.assign(httpSpan.info, {
+    resourceName: 'StepFunction',
+    httpInfo: { host: 'StepFunction' },
+    messageId: messageId,
+  });
+  const stepSpan = Object.assign(httpSpan, { info: stepInfo });
+  SpansContainer.addSpan(stepSpan);
+};
+
 export default () => {
   shimmer.wrap(http, 'get', httpGetWrapper(http));
   shimmer.wrap(https, 'get', httpGetWrapper(https));

--- a/src/hooks/http.test.js
+++ b/src/hooks/http.test.js
@@ -543,4 +543,28 @@ describe('http hook', () => {
     httpHook.httpRequestOnWrapper({})(() => true)('response', () => true);
     // No exception.
   });
+
+  test('addStepFunctionEvent', () => {
+    globals.SpansContainer.addSpan = jest.fn(() => {});
+    awsSpan.getHttpSpan.mockReturnValueOnce({
+      id: '123',
+      type: 'http',
+      started: 123,
+      info: { additional: 'bla' },
+    });
+
+    httpHook.addStepFunctionEvent('123');
+
+    expect(globals.SpansContainer.addSpan).toHaveBeenCalledWith({
+      id: '123',
+      type: 'http',
+      info: {
+        resourceName: 'StepFunction',
+        httpInfo: { host: 'StepFunction' },
+        messageId: '123',
+        additional: 'bla',
+      },
+      started: 123,
+    });
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -11,9 +11,10 @@ module.exports = function({
   eventFilter = {},
   verbose = false,
   switchOff = false,
+  stepFunction = false,
 }) {
   verbose && setVerboseMode();
   switchOff && setSwitchOff();
 
-  return { trace: trace({ token, debug, edgeHost, switchOff, eventFilter }) };
+  return { trace: trace({ token, debug, edgeHost, switchOff, eventFilter, stepFunction }) };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -16,5 +16,14 @@ module.exports = function({
   verbose && setVerboseMode();
   switchOff && setSwitchOff();
 
-  return { trace: trace({ token, debug, edgeHost, switchOff, eventFilter, stepFunction }) };
+  return {
+    trace: trace({
+      token,
+      debug,
+      edgeHost,
+      switchOff,
+      eventFilter,
+      stepFunction,
+    }),
+  };
 };

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -29,6 +29,7 @@ describe('index', () => {
       edgeHost,
       switchOff: false,
       eventFilter: {},
+      stepFunction: false,
     });
     expect(spies.setVerboseMode).toHaveBeenCalled();
     spies.trace.mockClear();
@@ -44,6 +45,7 @@ describe('index', () => {
       edgeHost: undefined,
       switchOff: true,
       eventFilter: {},
+      stepFunction: false,
     });
     expect(spies.setSwitchOff).toHaveBeenCalled();
   });
@@ -65,6 +67,7 @@ describe('index', () => {
       edgeHost,
       switchOff: false,
       eventFilter: {},
+      stepFunction: false,
     });
   });
 });

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -163,6 +163,7 @@ export const trace = ({
   edgeHost,
   switchOff,
   eventFilter,
+  stepFunction,
 }) => userHandler => async (event, context, callback) => {
   try {
     TracerGlobals.setHandlerInputs({ event, context });
@@ -172,6 +173,7 @@ export const trace = ({
       edgeHost,
       switchOff,
       eventFilter,
+      stepFunction,
     });
   } catch (err) {
     logger.warn('Failed to start tracer', err);

--- a/src/utils.js
+++ b/src/utils.js
@@ -395,22 +395,23 @@ export const safeExecute = (
   }
 };
 
-export const getLumigoEventKey = event => {
+export const recursiveGetKey = (event, keyToSearch) => {
   const noCircularEvent = noCirculars(event);
-  return recursiveGetLumigoEventKey(noCircularEvent);
+  return noCircularGetKey(noCircularEvent, keyToSearch);
 };
 
-const recursiveGetLumigoEventKey = noCircularEvent => {
+const noCircularGetKey = (noCircularEvent, keyToSearch) => {
   let foundValue = undefined;
-  Object.keys(noCircularEvent).some(function(k) {
-    if (k === LUMIGO_EVENT_KEY) {
+  const examineKey = k => {
+    if (k === keyToSearch) {
       foundValue = noCircularEvent[k];
       return true;
     }
     if (noCircularEvent[k] && typeof noCircularEvent[k] === 'object') {
-      foundValue = recursiveGetLumigoEventKey(noCircularEvent[k]);
+      foundValue = noCircularGetKey(noCircularEvent[k], keyToSearch);
       return foundValue !== undefined;
     }
-  });
+  };
+  Object.keys(noCircularEvent).some(examineKey);
   return foundValue;
 };

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -10,8 +10,7 @@ import {
   LUMIGO_SECRET_MASKING_REGEX_BACKWARD_COMP,
   LUMIGO_SECRET_MASKING_REGEX,
   safeExecute,
-  getLumigoEventKey,
-  LUMIGO_EVENT_KEY,
+  recursiveGetKey,
 } from './utils';
 import { TracerGlobals } from './globals';
 import EventEmitter from 'events';
@@ -777,18 +776,18 @@ describe('utils', () => {
   });
 
   test('getLumigoEventKey', () => {
-    expect(getLumigoEventKey({ a: 1 })).toEqual(undefined);
-    expect(getLumigoEventKey({ a: 1, [LUMIGO_EVENT_KEY]: { b: 2 } })).toEqual({
+    expect(recursiveGetKey({ a: 1 }, 'key')).toEqual(undefined);
+    expect(recursiveGetKey({ a: 1, key: { b: 2 } }, 'key')).toEqual({
       b: 2,
     });
-    expect(
-      getLumigoEventKey({ a: 1, b: { [LUMIGO_EVENT_KEY]: { c: 3 } } })
-    ).toEqual({ c: 3 });
+    expect(recursiveGetKey({ a: 1, b: { key: { c: 3 } } }, 'key')).toEqual({
+      c: 3,
+    });
 
     const circular = { a: 1 };
     circular.b = circular;
-    expect(getLumigoEventKey(circular)).toEqual(undefined);
-    circular[LUMIGO_EVENT_KEY] = { c: 3 };
-    expect(getLumigoEventKey(circular)).toEqual({ c: 3 });
+    expect(recursiveGetKey(circular, 'key')).toEqual(undefined);
+    circular.key = { c: 3 };
+    expect(recursiveGetKey(circular, 'key')).toEqual({ c: 3 });
   });
 });

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -17,6 +17,7 @@ import EventEmitter from 'events';
 import https from 'https';
 import crypto from 'crypto';
 import { isDebug } from './logger';
+import { GET_KEY_DEPTH_ENV_KEY } from './utils';
 
 jest.mock('https');
 jest.mock('../package.json', () => ({
@@ -775,7 +776,7 @@ describe('utils', () => {
     // No exception.
   });
 
-  test('getLumigoEventKey', () => {
+  test('recursiveGetKey', () => {
     expect(recursiveGetKey({ a: 1 }, 'key')).toEqual(undefined);
     expect(recursiveGetKey({ a: 1, key: { b: 2 } }, 'key')).toEqual({
       b: 2,
@@ -789,5 +790,14 @@ describe('utils', () => {
     expect(recursiveGetKey(circular, 'key')).toEqual(undefined);
     circular.key = { c: 3 };
     expect(recursiveGetKey(circular, 'key')).toEqual({ c: 3 });
+
+    const tooDeep = { a: { b: { c: { d: { e: { key: "I'm here" } } } } } };
+    process.env[GET_KEY_DEPTH_ENV_KEY] = undefined;
+    expect(recursiveGetKey(tooDeep, 'key')).toEqual(undefined);
+    process.env[GET_KEY_DEPTH_ENV_KEY] = 'bla';
+    expect(recursiveGetKey(tooDeep, 'key')).toEqual(undefined);
+    process.env[GET_KEY_DEPTH_ENV_KEY] = '8';
+    expect(recursiveGetKey(tooDeep, 'key')).toEqual("I'm here");
+    process.env[GET_KEY_DEPTH_ENV_KEY] = undefined;
   });
 });


### PR DESCRIPTION
Two simple additions:
* when the step finishes, we add a new key to the event that contains a special messageId
* when the step begins, we extract from the event the messageId (search for it recursively, because the step function configuration can change its position)