### PR TITLE
RD-3124 - fix: omit keys before prune strings

### DIFF
--- a/src/spans/awsSpan.test.js
+++ b/src/spans/awsSpan.test.js
@@ -472,7 +472,7 @@ describe('awsSpan', () => {
       host: 'your.mind.com',
       request: {
         body: '"the first rule of fight club"',
-        headers: '{"Tyler":"Durden","secretKey":"lumigo"}',
+        headers: '{"Tyler":"Durden","secretKey":"****"}',
         host: 'your.mind.com',
       },
       response: {

--- a/src/utils.js
+++ b/src/utils.js
@@ -249,7 +249,7 @@ export const prune = (str, maxLength = MAX_ENTITY_SIZE) =>
   (str || '').substr(0, maxLength);
 
 export const stringifyAndPrune = (obj, maxLength = MAX_ENTITY_SIZE) =>
-  prune(JSON.stringify(obj), maxLength);
+  prune(JSON.stringify(omitKeys(obj)), maxLength);
 
 export const pruneData = (data, maxLength) =>
   isString(data) ? prune(data, maxLength) : stringifyAndPrune(data, maxLength);

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -398,6 +398,14 @@ describe('utils', () => {
     expect(utils.stringifyAndPrune(obj)).toEqual(JSON.stringify(obj));
   });
 
+  test('stringifyAndPrune - omitting keys from pruned data', () => {
+    const obj = { secret: '1234', long: '1'.repeat(2000) };
+
+    expect(utils.stringifyAndPrune(obj, 30)).toEqual(
+      '{"secret":"****","long":"11111'
+    );
+  });
+
   test('pruneData', () => {
     const obj = {
       founder: 'Elon Musk',


### PR DESCRIPTION
The problem: we don't omit keys of pruned data because it's not a legal json
Solution: omit keys before prune