### PR TITLE
Rd 3388 ddb batch parsing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
       - run: cd ../dashboard && npm i
       - run: cd ../dashboard && ./scripts/prepare_env.sh --profile $(cat ~/envs/cypress.env.json | jq -r '.PROFILE_NAME') --env $(cat ~/envs/cypress.env.json | jq -r '.ENV')
       - run: cd ../integration-tests/src/e2e-test && npm i
-      - run: (cd ../dashboard && npm run start:ci) & (cd ../integration-testing && ./src/e2e-test/node_modules/.bin/wait-on http://127.0.0.1:3000 && npm run cypress:run)
+      - run: (cd ../dashboard && npm run start:ci) & (cd ../integration-tests && ./src/e2e-test/node_modules/.bin/wait-on http://127.0.0.1:3000 && npm run cypress:run)
       - store_artifacts:
           path: ~/integration-tests/src/e2e-test/cypress/videos
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
       - run: cd ../dashboard && npm i
       - run: cd ../dashboard && ./scripts/prepare_env.sh --profile $(cat ~/envs/cypress.env.json | jq -r '.PROFILE_NAME') --env $(cat ~/envs/cypress.env.json | jq -r '.ENV')
       - run: cd ../integration-tests/src/e2e-test && npm i
-      - run: (cd ../dashboard && npm run start:ci) & (cd ~/integration-testing && ./src/e2e-test/node_modules/.bin/wait-on http://127.0.0.1:3000 && npm run cypress:run)
+      - run: (cd ../dashboard && npm run start:ci) & (cd ../integration-testing && ./src/e2e-test/node_modules/.bin/wait-on http://127.0.0.1:3000 && npm run cypress:run)
       - store_artifacts:
           path: ~/integration-tests/src/e2e-test/cypress/videos
       - store_artifacts:

--- a/src/hooks/http.test.js
+++ b/src/hooks/http.test.js
@@ -1,4 +1,4 @@
-import { getRandomString, lowerCaseObjectKeys, MAX_ENTITY_SIZE } from '../utils';
+import { lowerCaseObjectKeys } from '../utils';
 import EventEmitter from 'events';
 import defaultHttp, { wrapHttp } from './http';
 import MockDate from 'mockdate';
@@ -75,27 +75,6 @@ describe('http hook', () => {
 
     expect(requestData).toEqual({
       body: 'HTTP BODY2',
-    });
-  });
-
-  test('httpRequestEmitBeforeHookWrapper -> handle big input', () => {
-    const requestData = {
-      body: '',
-    };
-    const body = getRandomString(MAX_ENTITY_SIZE * 2);
-    const emitEventName = 'socket';
-    const emitArg = {
-      _httpMessage: {
-        _hasBody: true,
-        output: [`HTTP BODY1\n${body}`],
-      },
-    };
-    const wrapper = httpHook.httpRequestEmitBeforeHookWrapper(requestData);
-    wrapper([emitEventName, emitArg]);
-
-    const expectedBody = body.substr(0, MAX_ENTITY_SIZE);
-    expect(requestData).toEqual({
-      body: expectedBody,
     });
   });
 
@@ -198,21 +177,6 @@ describe('http hook', () => {
     wrapper([firstArg, secArg]);
 
     expect(requestData).toEqual({ body: 'BODY' });
-  });
-
-  test('httpRequestWriteBeforeHookWrapper -> handle big payload', () => {
-    const requestData = {
-      body: '',
-    };
-
-    const firstArg = getRandomString(MAX_ENTITY_SIZE * 2);
-    const secArg = () => {};
-
-    const wrapper = httpHook.httpRequestWriteBeforeHookWrapper(requestData);
-    wrapper([firstArg, secArg]);
-
-    const expectedBody = firstArg.substr(0, MAX_ENTITY_SIZE);
-    expect(requestData).toEqual({ body: expectedBody });
   });
 
   test('httpRequestWriteBeforeHookWrapper -> not override body', () => {
@@ -423,19 +387,6 @@ describe('http hook', () => {
     httpHook.httpRequestEndWrapper(requestData)([data, encoding, callback]);
 
     expect(requestData).toEqual({ body: body });
-  });
-
-  test('httpRequestEndWrapper -> handle big input', () => {
-    const body = getRandomString(MAX_ENTITY_SIZE * 2);
-    const requestData = { body: '' };
-
-    const data = body;
-    const encoding = 'utf8';
-    const callback = jest.fn();
-    httpHook.httpRequestEndWrapper(requestData)([data, encoding, callback]);
-
-    const expectedBody = body.substr(0, MAX_ENTITY_SIZE);
-    expect(requestData).toEqual({ body: expectedBody });
   });
 
   test('httpRequestArguments -> no arguments', () => {

--- a/src/parsers/aws.js
+++ b/src/parsers/aws.js
@@ -25,7 +25,7 @@ const extractDynamodbMessageId = (reqBody, method) => {
 
 const extractDynamodbTableName = (reqBody, method) => {
   const tableName = (reqBody['TableName'] && reqBody.TableName) || '';
-  if (!tableName && method === 'BatchWriteItem') {
+  if (!tableName && ['BatchWriteItem', 'BatchGetItem'].includes(method)) {
     return Object.keys(reqBody.RequestItems)[0];
   }
   return tableName;

--- a/src/parsers/aws.test.js
+++ b/src/parsers/aws.test.js
@@ -87,6 +87,29 @@ describe('aws parser', () => {
     };
     expect(aws.dynamodbParser(requestDataWriteBatch)).toEqual(expectedWriteBatch);
 
+    const bodyGetBatch = JSON.stringify({
+      ReturnConsumedCapacity: "TOTAL",
+      RequestItems: {
+        [resourceName]: {
+          Keys: [{ key: { S: 'value' } }]
+        }
+      }
+    });
+    const headersGetBatch = {
+      'x-amz-target': 'DynamoDB_20120810.BatchGetItem',
+    };
+    const requestDataGetBatch = {
+      headers: headersGetBatch,
+      body: bodyGetBatch,
+    };
+    const expectedDataGetBatch = {
+      awsServiceData: {
+        resourceName: resourceName,
+        dynamodbMethod: 'BatchGetItem',
+      },
+    };
+    expect(aws.dynamodbParser(requestDataGetBatch)).toEqual(expectedDataGetBatch);
+
     const bodyDeleteBatch = JSON.stringify({
       RequestItems: {
         [resourceName]: [{ DeleteRequest: { Key: { key: { S: 'value' } } } }],

--- a/src/parsers/aws.test.js
+++ b/src/parsers/aws.test.js
@@ -88,12 +88,11 @@ describe('aws parser', () => {
     expect(aws.dynamodbParser(requestDataWriteBatch)).toEqual(expectedWriteBatch);
 
     const bodyGetBatch = JSON.stringify({
-      ReturnConsumedCapacity: "TOTAL",
       RequestItems: {
         [resourceName]: {
-          Keys: [{ key: { S: 'value' } }]
-        }
-      }
+          Keys: [{ key: { S: 'value' } }],
+        },
+      },
     });
     const headersGetBatch = {
       'x-amz-target': 'DynamoDB_20120810.BatchGetItem',


### PR DESCRIPTION
Solve two problems:
1. ddb.batchGetItem - extract the resource name
2. `getAwsServiceData` ran on pruned data, which cause parsing problem