### PR TITLE
feat: executionTags support undefined

### DIFF
--- a/src/globals.js
+++ b/src/globals.js
@@ -77,7 +77,7 @@ export const ExecutionTags = (() => {
     try {
       logger.debug(`Adding tag: ${key} - ${value}`);
       if (!validateTag(key, value, shouldLogErrors)) return false;
-      global.tags.push({ key, value });
+      global.tags.push({ key: String(key), value: String(value) });
     } catch (err) {
       shouldLogErrors && logger.warnClient(ADD_TAG_ERROR_MSG_PREFIX);
       logger.warn(ADD_TAG_ERROR_MSG_PREFIX, err);

--- a/src/globals.js
+++ b/src/globals.js
@@ -73,11 +73,13 @@ export const ExecutionTags = (() => {
     return true;
   };
 
+  const normalizeTag = val => (val === undefined || val === null ? null : String(val));
+
   const addTag = (key, value, shouldLogErrors = true) => {
     try {
       logger.debug(`Adding tag: ${key} - ${value}`);
       if (!validateTag(key, value, shouldLogErrors)) return false;
-      global.tags.push({ key: String(key), value: String(value) });
+      global.tags.push({ key: normalizeTag(key), value: normalizeTag(value) });
     } catch (err) {
       shouldLogErrors && logger.warnClient(ADD_TAG_ERROR_MSG_PREFIX);
       logger.warn(ADD_TAG_ERROR_MSG_PREFIX, err);

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -88,7 +88,7 @@ describe('index', () => {
     const actualTags = sentSpans.filter(span => !span.id.endsWith('_started'))[0][
       EXECUTION_TAGS_KEY
     ];
-    expect(actualTags).toEqual([{ key: 'k', value: 'undefined' }]);
+    expect(actualTags).toEqual([{ key: 'k', value: null }]);
   });
 
   test('execution tags - non async handler', async () => {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -72,6 +72,25 @@ describe('index', () => {
     expect(actualTags).toEqual([{ key: 'k0', value: 'v0' }, { key: 'k1', value: 'v1' }]);
   });
 
+  test('execution tags - with undefined', async () => {
+    const context = { getRemainingTimeInMillis: () => 30000 };
+
+    const lumigoImport = require('./index');
+    const lumigo = lumigoImport({ token: 'T' });
+    const userHandler = async (event, context, callback) => {
+      lumigoImport.addExecutionTag('k', undefined);
+      return 'retVal';
+    };
+    const result = await lumigo.trace(userHandler)({}, context, jest.fn());
+
+    expect(result).toEqual('retVal');
+    const sentSpans = AxiosMocker.getSentSpans()[1];
+    const actualTags = sentSpans.filter(span => !span.id.endsWith('_started'))[0][
+      EXECUTION_TAGS_KEY
+    ];
+    expect(actualTags).toEqual([{ key: 'k', value: 'undefined' }]);
+  });
+
   test('execution tags - non async handler', async () => {
     const context = { getRemainingTimeInMillis: () => 30000 };
 


### PR DESCRIPTION
Sometimes the execution tag had `key` and it didn't have `value`, there should always be both: `key` and `value`.