### PR TITLE
feat(spans): add neo4j support

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -5,6 +5,7 @@ import { hookRedis } from './redis';
 import { hookPg } from './pg';
 import { hookMySql } from './mySql';
 import { hookMssql } from './msSql';
+import { hookNeo4j } from './neo4j';
 
 export default () => {
   if (!isSwitchedOff() && isAwsEnvironment()) {
@@ -15,6 +16,7 @@ export default () => {
       hookPg();
       hookMySql();
       hookMssql();
+      hookNeo4j();
       setLambdaWrapped();
     }
   }

--- a/src/hooks/neo4j.js
+++ b/src/hooks/neo4j.js
@@ -1,0 +1,73 @@
+import { safeRequire } from '../utils/requireUtils';
+import * as logger from '../logger';
+import { hook } from '../extender';
+import { getRandomId } from '../utils';
+import { SpansContainer, TracerGlobals } from '../globals';
+import { extendNeo4jSpan, createNeo4jSpan } from '../spans/neo4jSpan';
+import { payloadStringify } from '../utils/payloadStringify';
+import { getCurrentTransactionId, NEO4J_SPAN } from '../spans/awsSpan';
+
+function queryBeforeHook(args, extenderContext) {
+  const awsRequestId = TracerGlobals.getHandlerInputs().context.awsRequestId;
+  const transactionId = getCurrentTransactionId();
+  const query = args[0];
+  const params = args[1];
+  const spanId = getRandomId();
+  const started = Date.now();
+
+  const connectionHolder = this._connectionHolderWithMode(this._mode);
+  const connectionParameters = {
+    mode: this._mode,
+    host: connectionHolder._connectionProvider._seedRouter._host,
+    port: connectionHolder._connectionProvider._seedRouter._port,
+    database: connectionHolder._database,
+    user: connectionHolder._connectionProvider._authToken.principal,
+  };
+
+  const span = createNeo4jSpan(
+    transactionId,
+    awsRequestId,
+    spanId,
+    { started },
+    { connectionParameters, query, params },
+    NEO4J_SPAN
+  );
+
+  SpansContainer.addSpan(span);
+  extenderContext.currentSpan = span;
+}
+
+const createResultHook = currentSpan => originalResult => {
+  const ended = Date.now();
+  const extendedSpan = extendNeo4jSpan(currentSpan, {
+    ended,
+    response: payloadStringify(originalResult.records),
+    summary: payloadStringify(originalResult.summary),
+  });
+  SpansContainer.addSpan(extendedSpan);
+};
+
+const createErrorHook = currentSpan => error => {
+  const ended = Date.now();
+  const extendedSpan = extendNeo4jSpan(currentSpan, {
+    ended,
+    error: payloadStringify(error),
+  });
+  SpansContainer.addSpan(extendedSpan);
+};
+
+function queryAfterHook(args, originalFnResult, extenderContext) {
+  const { currentSpan } = extenderContext;
+  originalFnResult.then(createResultHook(currentSpan)).catch(createErrorHook(currentSpan));
+}
+
+export const hookNeo4j = (neo4JClient = null) => {
+  const neo4j = neo4JClient || safeRequire('neo4j-driver/lib/session.js');
+  if (neo4j && neo4j.default) {
+    logger.info('Starting to instrument neo4j');
+    hook(neo4j.default.prototype, 'run', {
+      beforeHook: queryBeforeHook,
+      afterHook: queryAfterHook,
+    });
+  }
+};

--- a/src/hooks/neo4j.test.js
+++ b/src/hooks/neo4j.test.js
@@ -1,0 +1,91 @@
+import { createMockedClient, createMockedResponse } from '../../testUtils/neo4jMocker';
+import { SpansContainer, TracerGlobals } from '../globals';
+import { HandlerInputesBuilder } from '../../testUtils/handlerInputesBuilder';
+import { Neo4jSpanBuilder } from '../../testUtils/neo4jSpanBuilder';
+import { payloadStringify } from '../utils/payloadStringify';
+import { NEO4J_SPAN } from '../spans/awsSpan';
+import { hookNeo4j } from './neo4j';
+
+const DUMMY_OPTIONS = {
+  mode: 'READ',
+  host: 'localhost',
+  port: 7687,
+  user: 'neo4j',
+  database: 'neo4j',
+};
+
+const createHookedNeo4jSession = (mockOptions = {}) => {
+  const Session = createMockedClient(mockOptions);
+  hookNeo4j({ default: Session });
+
+  const mode = DUMMY_OPTIONS.mode;
+  const database = DUMMY_OPTIONS.database;
+  const connectionProvider = {
+    _authToken: {
+      principal: DUMMY_OPTIONS.user,
+    },
+    _seedRouter: {
+      _host: DUMMY_OPTIONS.host,
+      _port: DUMMY_OPTIONS.port,
+    },
+  };
+
+  const session = new Session(mode, connectionProvider, {}, database);
+  return session;
+};
+
+const createBaseBuilderFromSpan = span =>
+  new Neo4jSpanBuilder()
+    .withId(span.id)
+    .withType(NEO4J_SPAN)
+    .withStarted(span.started)
+    .withEnded(span.ended);
+
+describe('neo4j', () => {
+  beforeEach(() => {
+    const handlerInputs = new HandlerInputesBuilder().build();
+    TracerGlobals.setHandlerInputs(handlerInputs);
+  });
+
+  test('hook -> run (text: string, params: object) -> success', async () => {
+    const query = 'MATCH (u:User {id: $id}) RETURN u';
+    const params = { id: '2fce6d1c-b060-4e3c-860a-9d6b3f01504f' };
+    const response = createMockedResponse(query, params);
+    const client = createHookedNeo4jSession({ response });
+
+    await client.run(query, params);
+    const spans = SpansContainer.getSpans();
+    expect(spans).toEqual([
+      createBaseBuilderFromSpan(spans[0])
+        .withConnectionParameters(DUMMY_OPTIONS)
+        .withQuery(query)
+        .withParams(payloadStringify(params))
+        .withResponse(payloadStringify(response.records))
+        .withSummary(payloadStringify(response.summary))
+        .build(),
+    ]);
+  });
+
+  test('hook -> run (text: string, params: object) -> error', async () => {
+    const query = 'not-a-neo4j-query';
+    const params = {};
+
+    const error = new Error('Invalid Query');
+    const client = createHookedNeo4jSession({ error });
+    let foundError = false;
+
+    await client.run(query, params).catch(() => {
+      foundError = true;
+    });
+    const spans = SpansContainer.getSpans();
+    expect(spans).toEqual([
+      createBaseBuilderFromSpan(spans[0])
+        .withConnectionParameters(DUMMY_OPTIONS)
+        .withQuery(query)
+        .withParams(payloadStringify(params))
+        .withError(payloadStringify(error))
+        .build(),
+    ]);
+    expect(foundError).toBeTruthy();
+  });
+});

--- a/src/spans/awsSpan.js
+++ b/src/spans/awsSpan.js
@@ -39,6 +39,7 @@ export const REDIS_SPAN = 'redis';
 export const PG_SPAN = 'pg';
 export const MSSQL_SPAN = 'msSql';
 export const MYSQL_SPAN = 'mySql';
+export const NEO4J_SPAN = 'neo4j';
 
 export const getSpanInfo = () => {
   const tracer = getTracerInfo();

--- a/src/spans/neo4jSpan.js
+++ b/src/spans/neo4jSpan.js
@@ -1,0 +1,37 @@
+import { getBasicChildSpan } from './awsSpan';
+import { payloadStringify, prune } from '../utils/payloadStringify';
+import { getEventEntitySize } from '../utils';
+
+export const createNeo4jSpan = (
+  transactionId,
+  awsRequestId,
+  spanId,
+  requestMetadata,
+  dbFields,
+  spanType
+) => {
+  const baseSpan = getBasicChildSpan(transactionId, awsRequestId, spanId, spanType);
+  return {
+    ...baseSpan,
+    started: requestMetadata.started,
+    connectionParameters: dbFields.connectionParameters,
+    query: prune(dbFields.query, getEventEntitySize()),
+    params: dbFields.params ? payloadStringify(dbFields.params) : null,
+  };
+};
+
+export const extendNeo4jSpan = (currentSpan, extendData) => {
+  // This function is not pure to ensure performance
+  if (extendData.response) {
+    currentSpan.response = extendData.response;
+  }
+  if (extendData.summary) {
+    currentSpan.summary = extendData.summary;
+  }
+  if (extendData.error) {
+    currentSpan.error = extendData.error;
+  }
+  currentSpan.ended = extendData.ended;
+
+  return currentSpan;
+};

--- a/testUtils/neo4jMocker.js
+++ b/testUtils/neo4jMocker.js
@@ -1,0 +1,106 @@
+export const createMockedResponse = (query, params) => {
+  return {
+    records: [
+      {
+        keys: ['u'],
+        length: 1,
+        _fields: [
+          {
+            identity: {
+              low: 0,
+              high: 0,
+            },
+            labels: ['User'],
+            properties: {
+              id: '2fce6d1c-b060-4e3c-860a-9d6b3f01504f',
+              lastName: 'Doe',
+              firstName: 'John',
+              email: 'j.doe@example.com',
+            },
+          },
+        ],
+        _fieldLookup: {
+          u: 0,
+        },
+      },
+    ],
+    summary: {
+      query: {
+        text: query,
+        parameters: params,
+      },
+      queryType: 'r',
+      counters: {
+        _stats: {
+          nodesCreated: 0,
+          nodesDeleted: 0,
+          relationshipsCreated: 0,
+          relationshipsDeleted: 0,
+          propertiesSet: 0,
+          labelsAdded: 0,
+          labelsRemoved: 0,
+          indexesAdded: 0,
+          indexesRemoved: 0,
+          constraintsAdded: 0,
+          constraintsRemoved: 0,
+        },
+        _systemUpdates: 0,
+      },
+      updateStatistics: {
+        _stats: {
+          nodesCreated: 0,
+          nodesDeleted: 0,
+          relationshipsCreated: 0,
+          relationshipsDeleted: 0,
+          propertiesSet: 0,
+          labelsAdded: 0,
+          labelsRemoved: 0,
+          indexesAdded: 0,
+          indexesRemoved: 0,
+          constraintsAdded: 0,
+          constraintsRemoved: 0,
+        },
+        _systemUpdates: 0,
+      },
+      plan: false,
+      profile: false,
+      notifications: [],
+      server: {
+        address: 'localhost:7687',
+        version: 'Neo4j/4.1.4',
+      },
+      database: {
+        name: 'neo4j',
+      },
+    },
+  };
+};
+
+export const createMockedClient = (mockedOptions = {}) => {
+  const { error, response } = mockedOptions;
+
+  const Session = function(mode, connectionProvider, bookmark, database) {
+    this._mode = mode;
+    this._connectionHolderWithMode = () => {
+      return {
+        _database: database,
+        _connectionProvider: connectionProvider,
+      };
+    };
+    return this;
+  };
+
+  const runQuery = function() {
+    return new Promise((resolve, reject) => {
+      if (error) {
+        reject(error);
+      }
+
+      resolve(response);
+    });
+  };
+
+  Session.prototype.run = runQuery;
+
+  return Session;
+};

--- a/testUtils/neo4jSpanBuilder.js
+++ b/testUtils/neo4jSpanBuilder.js
@@ -1,0 +1,82 @@
+import { HttpSpanBuilder } from './httpSpanBuilder';
+
+export class Neo4jSpanBuilder {
+  constructor() {
+    const baseSpan = {
+      account: HttpSpanBuilder.DEFAULT_ACCOUNT,
+      ended: 1256,
+      id: 'not-a-random-id',
+      info: {
+        logGroupName: `/aws/lambda/${HttpSpanBuilder.DEFAULT_FUNC_NAME}`,
+        logStreamName: '2019/05/16/[$LATEST]8bcc747eb4ff4897bf6eba48797c0d73',
+        traceId: HttpSpanBuilder.DEFAULT_TRACE_ID,
+        tracer: HttpSpanBuilder.DEFAULT_TRACER,
+      },
+      memoryAllocated: '1024',
+      messageVersion: 2,
+      parentId: HttpSpanBuilder.DEFAULT_PARENT_ID,
+      reporterAwsRequestId: HttpSpanBuilder.DEFAULT_PARENT_ID,
+      readiness: 'cold',
+      region: HttpSpanBuilder.DEFAULT_REGION,
+      invokedArn: HttpSpanBuilder.DEFAULT_ARN,
+      invokedVersion: HttpSpanBuilder.DEFAULT_VERSION,
+      runtime: 'AWS_Lambda_nodejs8.10',
+      started: 1234,
+      token: '',
+      transactionId: '64a1b06067c2100c52e51ef4',
+      type: 'neo4j',
+      vendor: 'AWS',
+      version: '$LATEST',
+    };
+    this._span = {
+      ...baseSpan,
+      connectionParameters: null,
+      query: null,
+      params: '{}',
+    };
+  }
+
+  withStarted = started => {
+    this._span.started = started;
+    return this;
+  };
+  withId = id => {
+    this._span.id = id;
+    return this;
+  };
+  withEnded = ended => {
+    this._span.ended = ended;
+    return this;
+  };
+  withConnectionParameters = connectionParameters => {
+    this._span.connectionParameters = connectionParameters;
+    return this;
+  };
+  withQuery = query => {
+    this._span.query = query;
+    return this;
+  };
+  withResponse = response => {
+    this._span.response = response;
+    return this;
+  };
+  withSummary = summary => {
+    this._span.summary = summary;
+    return this;
+  };
+  withError = error => {
+    this._span.error = error;
+    return this;
+  };
+  withParams = params => {
+    this._span.params = params;
+    return this;
+  };
+  withType = type => {
+    this._span.type = type;
+    return this;
+  };
+  build = () => {
+    return this._span;
+  };
+}


### PR DESCRIPTION
This PR adds support for the [neo4j-driver](https://github.com/neo4j/neo4j-javascript-driver)

It adds a hook to the [Session.run](https://github.com/neo4j/neo4j-javascript-driver/blob/4.3/src/session.js#L97) method and collects useful data.

Some insights about the schema:

From **beforeHook**
    
`connectionParameters.mode`: `READ` or `WRITE`
`connectionParameters.host`: db host name
`connectionParameters.port`: port
`connectionParameters.database`: database name
`connectionParameters.user`: username for database connection
`query`: the input query passed
`params`: parameters for the query

From **afterHook**
`response`: The result of the query
`summary`: Somme statistics about the query execution returned by neo4j
OR
`error`: The error thrown by the driver

Example of generated span (truncated for clarity and privacy)

```json
{
    // truncated
    "type": "neo4j",
    "started": 1608809335218,
    "connectionParameters": {
        "mode": "READ",
        "host": "db-1234567890.graphenedb.com",
        "port": 7687,
        "database": "",
        "user": "neo4j"
    },
    "query": "MATCH (u:User { id: $id }) RETURN u;",
    "params": "{\"id\":\"49e9878f-18cc-4dd4-9aa1-c6a39b5d4c12\"}",
    "response": "[{\"keys\":\"****\",\"length\":1,\"_fields\":[{\"name\":\"John\"[TRUNCATED]",
    "summary": "{\"query\":{\"text\":\"MATCH (u:User { id: $id }) RETURN u;\",\"parameters\":{\"id\":\"49e9878f-18cc-4dd4-9aa1-c6a39b5d4c12\"}},\"queryType\":\"r\",[TRUNCATED]",
    "ended": 1608809335333
}
```