### PR TITLE
fix(neo4j): add database fallback and don't scrub keys

### DIFF
--- a/src/hooks/neo4j.js
+++ b/src/hooks/neo4j.js
@@ -41,7 +41,8 @@ const createResultHook = currentSpan => originalResult => {
   const ended = Date.now();
   const extendedSpan = extendNeo4jSpan(currentSpan, {
     ended,
-    response: payloadStringify(originalResult.records),
+    database: originalResult.summary.database.name,
+    response: payloadStringify(originalResult.records, undefined, [[], 'keys']),
     summary: payloadStringify(originalResult.summary),
   });
   SpansContainer.addSpan(extendedSpan);

--- a/src/hooks/neo4j.test.js
+++ b/src/hooks/neo4j.test.js
@@ -60,7 +60,7 @@ describe('neo4j', () => {
         .withConnectionParameters(DUMMY_OPTIONS)
         .withQuery(query)
         .withParams(payloadStringify(params))
-        .withResponse(payloadStringify(response.records))
+        .withResponse(payloadStringify(response.records, undefined, [[], 'keys']))
         .withSummary(payloadStringify(response.summary))
         .build(),
     ]);

--- a/src/spans/neo4jSpan.js
+++ b/src/spans/neo4jSpan.js
@@ -28,6 +28,9 @@ export const extendNeo4jSpan = (currentSpan, extendData) => {
   if (extendData.summary) {
     currentSpan.summary = extendData.summary;
   }
+  if (extendData.database) {
+    currentSpan.connectionParameters.database = extendData.database;
+  }
   if (extendData.error) {
     currentSpan.error = extendData.error;
   }


### PR DESCRIPTION
As discussed with @doriaviram, I added a fallback for the `database` field to use the one from the `summary` field when the query response is received. This field is not required in the neo4j `session()` method, so we don't always get it in the before hook. When not provided, neo4j uses the default database. The summary field should always contain that information.
The only edge case is when the user does not provide the database name, and the query fails.

Bonus: I also fixed an issue where the `key` was obfuscated by `payloadStringify()`. These keys are safe, so I excluded them from the scrub.
 