### PR TITLE
fix: removeDuplicate implementation

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -507,4 +507,4 @@ export const isEmptyString = (str): boolean =>
   !!(!str || (typeof str === 'string' && str.length === 0));
 
 // @ts-ignore
-export const removeDuplicates = (arr) => [...new Set(arr)];
+export const removeDuplicates = (arr) => Array.from(new Set(arr));


### PR DESCRIPTION
building the previous implementation was created wrong code:
```
var __spreadArray = (this && this.__spreadArray) || function (to, from) {
    for (var i = 0, il = from.length, j = to.length; i < il; i++, j++)
        to[j] = from[i];
    return to;
};
var removeDuplicates = function (arr) { return __spreadArray([], new Set(arr)); };
```

I replaced this code will and will explore it further later.
The attached IT shows that this functionality didn't work before the change and currently works.