### PR TITLE
RD 6232 - handle buffer http body in httpRequestEndWrapper

### DIFF
--- a/src/hooks/httpUtils.js
+++ b/src/hooks/httpUtils.js
@@ -20,21 +20,13 @@ export const extractBodyFromEmitSocketEvent = (socketEventArgs) => {
   })();
 };
 
-export const extractBodyFromWriteFunc = (writeEventArgs) => {
+export const extractBodyFromWriteOrEndFunc = (writeEventArgs) => {
   return safeExecute(() => {
     if (isValidHttpRequestBody(writeEventArgs[0])) {
       const encoding = isEncodingType(writeEventArgs[1]) ? writeEventArgs[1] : 'utf8';
       return typeof writeEventArgs[0] === 'string'
         ? Buffer(writeEventArgs[0]).toString(encoding)
         : writeEventArgs[0].toString().substr(0, getEventEntitySize(false));
-    }
-  })();
-};
-
-export const extractBodyFromEndFunc = (endFuncArgs) => {
-  return safeExecute(() => {
-    if (isValidHttpRequestBody(endFuncArgs[0])) {
-      return endFuncArgs[0];
     }
   })();
 };

--- a/src/hooks/httpUtils.test.js
+++ b/src/hooks/httpUtils.test.js
@@ -1,6 +1,6 @@
 import {
   extractBodyFromEmitSocketEvent,
-  extractBodyFromWriteFunc,
+  extractBodyFromWriteOrEndFunc,
   isValidHttpRequestBody,
 } from './httpUtils';
 
@@ -44,55 +44,55 @@ describe('httpUtils', () => {
     expect(result).toEqual(undefined);
   });
 
-  test('extractBodyFromWriteFunc -> simple flow -> write(str)', () => {
+  test('extractBodyFromWriteOrEndFunc -> simple flow -> write(str)', () => {
     const firstArg = 'BODY';
 
-    const result = extractBodyFromWriteFunc([firstArg]);
+    const result = extractBodyFromWriteOrEndFunc([firstArg]);
 
     expect(result).toEqual(firstArg);
   });
 
-  test('extractBodyFromWriteFunc -> simple flow -> write(Buffer)', () => {
+  test('extractBodyFromWriteOrEndFunc -> simple flow -> write(Buffer)', () => {
     const firstArg = Buffer.from('BODY');
 
-    const result = extractBodyFromWriteFunc([firstArg]);
+    const result = extractBodyFromWriteOrEndFunc([firstArg]);
 
     expect(result).toEqual('BODY');
   });
 
-  test('extractBodyFromWriteFunc -> simple flow -> write(Buffer, encoding)', () => {
+  test('extractBodyFromWriteOrEndFunc -> simple flow -> write(Buffer, encoding)', () => {
     const firstArg = 'BODY';
     const secArg = 'base64';
 
-    const result = extractBodyFromWriteFunc([firstArg, secArg]);
+    const result = extractBodyFromWriteOrEndFunc([firstArg, secArg]);
 
     expect(result).toEqual('Qk9EWQ==');
   });
 
-  test('extractBodyFromWriteFunc -> simple flow -> write(Buffer, encoding, callback)', () => {
+  test('extractBodyFromWriteOrEndFunc -> simple flow -> write(Buffer, encoding, callback)', () => {
     const firstArg = Buffer.from('BODY');
     const secArg = 'base64';
     const thirdArg = () => {};
 
-    const result = extractBodyFromWriteFunc([firstArg, secArg, thirdArg]);
+    const result = extractBodyFromWriteOrEndFunc([firstArg, secArg, thirdArg]);
 
     expect(result).toEqual('BODY');
   });
 
-  test('extractBodyFromWriteFunc -> simple flow -> write(Buffer, callback)', () => {
+  test('extractBodyFromWriteOrEndFunc -> simple flow -> write(Buffer, callback)', () => {
     const firstArg = Buffer.from('BODY');
     const secArg = () => {};
 
-    const result = extractBodyFromWriteFunc([firstArg, secArg]);
+    const result = extractBodyFromWriteOrEndFunc([firstArg, secArg]);
 
     expect(result).toEqual('BODY');
   });
 
-  test('extractBodyFromWriteFunc -> simple flow -> write(str, callback)', () => {
+  test('extractBodyFromWriteOrEndFunc -> simple flow -> write(str, callback)', () => {
     const firstArg = 'BODY';
     const secArg = () => {};
 
-    const result = extractBodyFromWriteFunc([firstArg, secArg]);
+    const result = extractBodyFromWriteOrEndFunc([firstArg, secArg]);
 
     expect(result).toEqual('BODY');
   });


### PR DESCRIPTION
The problem here was that the `httpRequestEndWrapper` got `buffer` instead of `string`