### PR TITLE
feat: MongoDB 4.x support

### DIFF
--- a/src/extender.js
+++ b/src/extender.js
@@ -7,7 +7,7 @@ const noop = () => {};
 const isFunctionAlreadyWrapped = (fn) => fn && fn.__wrapped;
 
 export const hook = (module, funcName, options = {}, shimmerLib = shimmer) => {
-  const { isConstructor = true, beforeHook = noop, afterHook = noop } = options;
+  const { isConstructor = false, beforeHook = noop, afterHook = noop } = options;
   const safeBeforeHook = safeExecute(beforeHook, `before hook of ${funcName} fail`);
   const safeAfterHook = safeExecute(afterHook, `after hook of ${funcName} fail`);
   const extenderContext = {};

--- a/src/extender.js
+++ b/src/extender.js
@@ -27,11 +27,14 @@ export const hook = (module, funcName, options = {}, shimmerLib = shimmer) => {
              * If we are instrumenting a constructor, we need to use the 'new' keyword , and
              * there isn't really a great way to detect it other than looking into the error.
              */
-            if (err instanceof TypeError && err.message && err.message.startsWith('Class constructor')) {
+            if (
+              err instanceof TypeError &&
+              err.message &&
+              err.message.startsWith('Class constructor')
+            ) {
               try {
                 originalFnResult = new originalFn(...args);
-              } catch (err) {
-              }
+              } catch (err) {}
             }
           }
           safeAfterHook.call(this, args, originalFnResult, extenderContext);
@@ -39,7 +42,7 @@ export const hook = (module, funcName, options = {}, shimmerLib = shimmer) => {
         } catch (err) {
           logger.debug(`Wrapper for ${funcName} failed`, err);
         }
-      }
+      };
     };
     shimmerLib.wrap(module, funcName, wrapper);
   } catch (e) {

--- a/src/extender.js
+++ b/src/extender.js
@@ -34,7 +34,11 @@ export const hook = (module, funcName, options = {}, shimmerLib = shimmer) => {
             ) {
               try {
                 originalFnResult = new originalFn(...args);
-              } catch (err) {}
+              } catch (err) {
+                throw err;
+              }
+            } else {
+              throw err;
             }
           }
           safeAfterHook.call(this, args, originalFnResult, extenderContext);

--- a/src/extender.js
+++ b/src/extender.js
@@ -27,7 +27,7 @@ export const hook = (module, funcName, options = {}, shimmerLib = shimmer) => {
     };
     shimmerLib.wrap(module, funcName, wrapper);
   } catch (e) {
-    logger.debug(`Hooking of function ${funcName} failed`, e);
+    logger.warn(`Wrapping of function ${funcName} failed`, options);
   }
 };
 

--- a/src/extender.test.js
+++ b/src/extender.test.js
@@ -51,7 +51,7 @@ describe('extender', () => {
       isConstructor: true,
       afterHook: (args, clientInstance, extenderContext) => {
         clientInstance.value = 42;
-      }
+      },
     });
 
     expect(new dummy.DummyClass().value).toEqual(42);

--- a/src/extender.test.js
+++ b/src/extender.test.js
@@ -1,8 +1,10 @@
 import * as extender from './extender';
 import * as shimmer from 'shimmer';
+import * as dummy from './extender.testModule';
 
 export const DummyCounterService = (() => {
   let dummyCounter = 0;
+
   const incrementToDummyCounter = (count = 1) => {
     dummyCounter += count;
   };
@@ -40,6 +42,19 @@ describe('extender', () => {
     extender.hook(DummyCounterService, 'incrementToDummyCounter');
     DummyCounterService.incrementToDummyCounter();
     expect(DummyCounterService.getDummyCounter()).toEqual(1);
+  });
+
+  test('hook -> constructor flow', () => {
+    expect(new dummy.DummyClass().value).toEqual(0);
+
+    extender.hook(dummy, 'DummyClass', {
+      isConstructor: true,
+      afterHook: (args, clientInstance, extenderContext) => {
+        clientInstance.value = 42;
+      }
+    });
+
+    expect(new dummy.DummyClass().value).toEqual(42);
   });
 
   test('hook -> before Hook', () => {

--- a/src/extender.testModule.js
+++ b/src/extender.testModule.js
@@ -1,0 +1,6 @@
+export class DummyClass {
+    value;
+    constructor() {
+      this.value = 0;
+    }
+}

--- a/src/extender.testModule.js
+++ b/src/extender.testModule.js
@@ -1,6 +1,6 @@
 export class DummyClass {
-    value;
-    constructor() {
-      this.value = 0;
-    }
+  value;
+  constructor() {
+    this.value = 0;
+  }
 }

--- a/src/hooks/mongodb.js
+++ b/src/hooks/mongodb.js
@@ -1,3 +1,4 @@
+import { hook } from '../extender';
 import { SpansContainer, TracerGlobals } from '../globals';
 import * as logger from '../logger';
 import { getCurrentTransactionId } from '../spans/awsSpan';
@@ -72,27 +73,101 @@ const onFailedHook = (event) => {
   SpansContainer.addSpan(extendedMondoDbSpan);
 };
 
+function mongoClient4xBeforeConstructorHook(args, extenderContext) {
+  /*
+   * Inject the `monitorCommands: true` property in the options (2nd argument).
+   * If no options argument is given, well... now there is :D
+   */
+  switch (args.length) {
+    case 0:
+      /*
+       * Wait this is not possible. It is supposed to have at least the URL
+       * as first arg!
+       */
+      logger.debug('MongoDB 4.x instrumentation skipped: unexpected zero arguments to MongoClient constructor');
+      break;
+    case 1:
+      args.push({
+        monitorCommands: true,
+      });
+      break;
+    default:
+      switch (typeof args[1]) {
+        case 'object':
+          // TODO Check for `null`, which has type object?
+          args[1].monitorCommands = true;
+          break;
+        case 'undefined':
+          args[1] = {
+            monitorCommands: true,
+          };
+          break;
+        default:
+          logger.debug(`MongoDB 4.x instrumentation skipped: unexpected type of the 'options' argument: ${typeof optionsObject}`);
+      }
+  }
+}
+
+function mongoClient4xAfterConstructorHook(args, clientInstance, extenderContext) {
+  /*
+   * Turn on the command listener. This assumes the `monitorCommands` flag we
+   * add in the 'beforeConstructor' hook. The shape of the events we get from
+   * the MongoDB Client 4.x is the same as those that 3.x emitted with 'instrument'.
+   */
+  if (args.length > 1 && (typeof args[1]) === 'object' && args[1].monitorCommands === true) {
+    try {
+      clientInstance.on('commandStarted', safeExecute(onStartedHook));
+      clientInstance.on('commandSucceeded', safeExecute(onSucceededHook));
+      clientInstance.on('commandFailed', safeExecute(onFailedHook));
+    } catch (err) {
+      logger.debug(`MongoDB 4.x 'on' hooks cannot be applied to ${clientInstance}`, err);
+    }
+  } else {
+    logger.debug("MongoDB 4.x 'on' hooks skipped: monitorCommands was not set in the options");
+  }
+}
+
 export const hookMongoDb = (mongoLib) => {
   const mongoClient = mongoLib ? mongoLib : safeRequire('mongodb');
   const mongooseClients = safeRequire('node_modules/mongoose/node_modules/mongodb');
   const mongoClients = [mongoClient, mongooseClients].filter(Boolean);
-  if (mongoClients.length > 0) {
-    mongoClients.forEach((mongoClient) => {
-      logger.info('Starting to instrument MongoDB');
-      const listener = mongoClient.instrument({}, (err) => {
-        if (err) logger.warn('MongoDB instrumentation failed ', err);
+
+  if (!mongoClients) {
+    logger.debug('MongoDB not found');
+    return;
+  }
+
+  mongoClients.forEach((mongoLib) => {
+    if (mongoLib.instrument) {
+      // MongoDB 3.x
+      const listener = mongoLib.instrument({}, (err) => {
+        if (err) logger.warn('MongoDB 3.x instrumentation failed ', err);
       });
+
       const safeStartedHook = safeExecute(onStartedHook);
       const safeSucceededHook = safeExecute(onSucceededHook);
       const safeFailedHook = safeExecute(onFailedHook);
+
       safeExecute(() => {
         listener.on('started', safeStartedHook);
         listener.on('succeeded', safeSucceededHook);
         listener.on('failed', safeFailedHook);
       })();
-    });
-    logger.info('MongoDB instrumentation done');
-  } else {
-    logger.debug('MongoDB SDK not found');
-  }
+
+      logger.debug('MongoDB 3.x instrumentation applied');
+    } else if (mongoLib.MongoClient.prototype.on) {
+      logger.debug({
+        beforeHook: mongoClient4xBeforeConstructorHook,
+        afterHook: mongoClient4xAfterConstructorHook,
+      });
+      hook(mongoLib, 'MongoClient', {
+        beforeHook: mongoClient4xBeforeConstructorHook,
+        afterHook: mongoClient4xAfterConstructorHook,
+      });
+
+      // TODO Find a hook for catching connection issues.
+
+      logger.debug('MongoDB 4.x instrumentation applied');
+    }
+  });
 };

--- a/src/hooks/mongodb.js
+++ b/src/hooks/mongodb.js
@@ -160,11 +160,8 @@ export const hookMongoDb = (mongoLib) => {
 
       logger.debug('MongoDB 3.x instrumentation applied');
     } else if (mongoLib.MongoClient.prototype.on) {
-      logger.debug({
-        beforeHook: mongoClient4xBeforeConstructorHook,
-        afterHook: mongoClient4xAfterConstructorHook,
-      });
       hook(mongoLib, 'MongoClient', {
+        isConstructor: true,
         beforeHook: mongoClient4xBeforeConstructorHook,
         afterHook: mongoClient4xAfterConstructorHook,
       });

--- a/src/hooks/mongodb.js
+++ b/src/hooks/mongodb.js
@@ -84,7 +84,9 @@ function mongoClient4xBeforeConstructorHook(args, extenderContext) {
        * Wait this is not possible. It is supposed to have at least the URL
        * as first arg!
        */
-      logger.debug('MongoDB 4.x instrumentation skipped: unexpected zero arguments to MongoClient constructor');
+      logger.debug(
+        'MongoDB 4.x instrumentation skipped: unexpected zero arguments to MongoClient constructor'
+      );
       break;
     case 1:
       args.push({
@@ -103,7 +105,9 @@ function mongoClient4xBeforeConstructorHook(args, extenderContext) {
           };
           break;
         default:
-          logger.debug(`MongoDB 4.x instrumentation skipped: unexpected type of the 'options' argument: ${typeof optionsObject}`);
+          logger.debug(
+            `MongoDB 4.x instrumentation skipped: unexpected type of the 'options' argument: ${typeof optionsObject}`
+          );
       }
   }
 }
@@ -114,7 +118,7 @@ function mongoClient4xAfterConstructorHook(args, clientInstance, extenderContext
    * add in the 'beforeConstructor' hook. The shape of the events we get from
    * the MongoDB Client 4.x is the same as those that 3.x emitted with 'instrument'.
    */
-  if (args.length > 1 && (typeof args[1]) === 'object' && args[1].monitorCommands === true) {
+  if (args.length > 1 && typeof args[1] === 'object' && args[1].monitorCommands === true) {
     try {
       clientInstance.on('commandStarted', safeExecute(onStartedHook));
       clientInstance.on('commandSucceeded', safeExecute(onSucceededHook));


### PR DESCRIPTION
* Added support for MongoDB 4.x 
* Improved extender.js to be able to wrap functions that are constructors (which is needed by MongoDB to ensure that the `monitorCommands` flag is set in the client on instantiation 

TODOs:
* Tests + Itests
* Support for detecting failures and timeouts on connection