### PR TITLE
fix: mysql-2: support extract values in all known calling conventions

### DIFF
--- a/src/hooks/mySql.js
+++ b/src/hooks/mySql.js
@@ -36,6 +36,7 @@ function extractValuesFromArg(arg) {
   if (isObject(arg) && typeof arg === 'object' && !!arg['values']) {
     return arg['values'];
   }
+  return undefined;
 }
 
 function queryBeforeHook(args, extenderContext) {

--- a/src/hooks/mySql.test.js
+++ b/src/hooks/mySql.test.js
@@ -52,279 +52,338 @@ describe('mySql', () => {
     TracerGlobals.setHandlerInputs(handlerInputs);
   });
 
-  test('v2 -> hook -> query (text: string, callback: Function) -> success', (done) => {
-    const client = createHookedMySqlV2Client();
+  describe('v1 -> ', () => {
+    test('hook -> query (text: string, callback: Function) -> success', (done) => {
+      const client = createHookedMySqlV1Client();
 
-    client.query('SELECT * from users', () => {
-      const spans = SpansContainer.getSpans();
-      expect(spans).toEqual([
-        createBaseBuilderFromSpan(spans[0])
-          .withQuery('SELECT * from users')
-          .withConnectionParameters(DUMMY_OPTIONS)
-          .withResponse(createExpectedResponse())
-          .build(),
-      ]);
-      done();
+      client.query('SELECT * from users', () => {
+        const spans = SpansContainer.getSpans();
+        expect(spans).toEqual([
+          createBaseBuilderFromSpan(spans[0])
+            .withQuery('SELECT * from users')
+            .withConnectionParameters(DUMMY_OPTIONS)
+            .withResponse(createExpectedResponse())
+            .build(),
+        ]);
+        done();
+      });
+    });
+
+    test('hook -> query (text: string, values: List, callback: Function) -> success', (done) => {
+      const client = createHookedMySqlV1Client();
+
+      client.query('SELECT * from users', ['123'], () => {
+        const spans = SpansContainer.getSpans();
+        expect(spans).toEqual([
+          createBaseBuilderFromSpan(spans[0])
+            .withQuery('SELECT * from users')
+            .withConnectionParameters(DUMMY_OPTIONS)
+            .withValues(payloadStringify(['123']))
+            .withResponse(createExpectedResponse())
+            .build(),
+        ]);
+        done();
+      });
+    });
+
+    test('hook -> query (text: string, callback: Function) -> fail', (done) => {
+      const error = new Error('DuumyError');
+      const client = createHookedMySqlV1Client({ error });
+
+      client.query('SELECT * from users', () => {
+        const spans = SpansContainer.getSpans();
+        expect(spans).toEqual([
+          createBaseBuilderFromSpan(spans[0])
+            .withQuery('SELECT * from users')
+            .withConnectionParameters(DUMMY_OPTIONS)
+            .withError(payloadStringify(error))
+            .build(),
+        ]);
+        done();
+      });
+    });
+
+    test('hook -> query (text: string, values: List, callback: Function) -> fail', (done) => {
+      const error = new Error('DuumyError');
+      const client = createHookedMySqlV1Client({ error });
+
+      client.query('SELECT * from users', ['123'], () => {
+        const spans = SpansContainer.getSpans();
+        expect(spans).toEqual([
+          createBaseBuilderFromSpan(spans[0])
+            .withQuery('SELECT * from users')
+            .withConnectionParameters(DUMMY_OPTIONS)
+            .withValues(payloadStringify(['123']))
+            .withError(payloadStringify(error))
+            .build(),
+        ]);
+        done();
+      });
     });
   });
 
-  test('v2 -> hook -> query (text: string, callback: Function) -> sqlObject', (done) => {
-    const client = createHookedMySqlV2Client();
+  describe('v2 -> ', () => {
+    test('hook -> query (text: string, callback: Function) -> success', (done) => {
+      const client = createHookedMySqlV2Client();
 
-    const sql = {
-      _events: {},
-      _eventsCount: 1,
-      _callSite: {},
-      _ended: false,
-      _timer: {
-        _timeout: null,
-      },
-      sql: 'CALL usp_get_pending_requests(?,?,?)',
-      values: ['6784283985', '0', ''],
-      typeCast: true,
-      nestTables: false,
-      _resultSet: null,
-      _results: [],
-      _fields: [],
-      _index: 0,
-      _loadError: null,
-    };
-
-    const sqlObject = { sql };
-
-    const expectedQuery =
-      '{"sql":"CALL usp_get_pending_requests(?,?,?)","values":["6784283985","0",""],"typeCast":true,"nestTables":false}';
-
-    client.query(sqlObject, () => {
-      const spans = SpansContainer.getSpans();
-      expect(spans).toEqual([
-        createBaseBuilderFromSpan(spans[0])
-          .withQuery(expectedQuery)
-          .withConnectionParameters(DUMMY_OPTIONS)
-          .withResponse(createExpectedResponse())
-          .build(),
-      ]);
-      done();
+      client.query('SELECT * from users', () => {
+        const spans = SpansContainer.getSpans();
+        expect(spans).toEqual([
+          createBaseBuilderFromSpan(spans[0])
+            .withQuery('SELECT * from users')
+            .withConnectionParameters(DUMMY_OPTIONS)
+            .withResponse(createExpectedResponse())
+            .build(),
+        ]);
+        done();
+      });
     });
-  });
 
-  test('v2 -> hook -> query (text: string, callback: Function) -> Unknown query', (done) => {
-    const client = createHookedMySqlV2Client();
+    test('hook -> query (options: object, callback: Function) -> sqlObject', (done) => {
+      const client = createHookedMySqlV2Client();
 
-    client.query(1, () => {
-      const spans = SpansContainer.getSpans();
-      expect(spans).toEqual([
-        createBaseBuilderFromSpan(spans[0])
-          .withQuery('Unknown')
-          .withConnectionParameters(DUMMY_OPTIONS)
-          .withResponse(createExpectedResponse())
-          .build(),
-      ]);
-      done();
+      const sql = {
+        _events: {},
+        _eventsCount: 1,
+        _callSite: {},
+        _ended: false,
+        _timer: {
+          _timeout: null,
+        },
+        sql: 'CALL usp_get_pending_requests(?,?,?)',
+        values: ['6784283985', '0', ''],
+        typeCast: true,
+        nestTables: false,
+        _resultSet: null,
+        _results: [],
+        _fields: [],
+        _index: 0,
+        _loadError: null,
+      };
+
+      const sqlObject = { sql };
+
+      const expectedQuery =
+        '{"sql":"CALL usp_get_pending_requests(?,?,?)","values":["6784283985","0",""],"typeCast":true,"nestTables":false}';
+
+      client.query(sqlObject, () => {
+        const spans = SpansContainer.getSpans();
+        expect(spans).toEqual([
+          createBaseBuilderFromSpan(spans[0])
+            .withQuery(expectedQuery)
+            .withConnectionParameters(DUMMY_OPTIONS)
+            .withResponse(createExpectedResponse())
+            .build(),
+        ]);
+        done();
+      });
     });
-  });
 
-  test('v2 -> hook -> query (text: string, values: List, callback: Function) -> success', (done) => {
-    const client = createHookedMySqlV2Client();
+    test('hook -> query (options: Object, callback: Function) -> success', (done) => {
+      const client = createHookedMySqlV2Client();
 
-    client.query('SELECT * from users', ['123'], () => {
-      const spans = SpansContainer.getSpans();
-      expect(spans).toEqual([
-        createBaseBuilderFromSpan(spans[0])
-          .withQuery('SELECT * from users')
-          .withConnectionParameters(DUMMY_OPTIONS)
-          .withValues(payloadStringify(['123']))
-          .withResponse(createExpectedResponse())
-          .build(),
-      ]);
-      done();
+      client.query({ sql: 'SELECT * from users', values: ['123'] }, () => {
+        const spans = SpansContainer.getSpans();
+        expect(spans).toEqual([
+          createBaseBuilderFromSpan(spans[0])
+            .withQuery('SELECT * from users')
+            .withConnectionParameters(DUMMY_OPTIONS)
+            .withValues(payloadStringify(['123']))
+            .withResponse(createExpectedResponse())
+            .build(),
+        ]);
+        done();
+      });
     });
-  });
 
-  test('v2 -> hook -> object query (text: string, callback: Function) -> success', (done) => {
-    const client = createHookedMySqlV2Client();
+    test('hook -> query (text: string, callback: Function) -> Unknown query', (done) => {
+      const client = createHookedMySqlV2Client();
 
-    client.query({ sql: 'SELECT * from users' }, () => {
-      const spans = SpansContainer.getSpans();
-      expect(spans).toEqual([
-        createBaseBuilderFromSpan(spans[0])
-          .withQuery('SELECT * from users')
-          .withConnectionParameters(DUMMY_OPTIONS)
-          .withResponse(createExpectedResponse())
-          .build(),
-      ]);
-      done();
+      client.query(1, () => {
+        const spans = SpansContainer.getSpans();
+        expect(spans).toEqual([
+          createBaseBuilderFromSpan(spans[0])
+            .withQuery('Unknown')
+            .withConnectionParameters(DUMMY_OPTIONS)
+            .withResponse(createExpectedResponse())
+            .build(),
+        ]);
+        done();
+      });
     });
-  });
 
-  test('v2 -> hook -> query (text: string, callback: Function) -> fail', (done) => {
-    const error = new Error('DuumyError');
-    const client = createHookedMySqlV2Client({ error });
+    test('hook -> query (text: string, values: List, callback: Function) -> success', (done) => {
+      const client = createHookedMySqlV2Client();
 
-    client.query('SELECT * from users', () => {
-      const spans = SpansContainer.getSpans();
-      expect(spans).toEqual([
-        createBaseBuilderFromSpan(spans[0])
-          .withQuery('SELECT * from users')
-          .withConnectionParameters(DUMMY_OPTIONS)
-          .withError(payloadStringify(error))
-          .build(),
-      ]);
-      done();
+      client.query('SELECT * from users', ['123'], () => {
+        const spans = SpansContainer.getSpans();
+        expect(spans).toEqual([
+          createBaseBuilderFromSpan(spans[0])
+            .withQuery('SELECT * from users')
+            .withConnectionParameters(DUMMY_OPTIONS)
+            .withValues(payloadStringify(['123']))
+            .withResponse(createExpectedResponse())
+            .build(),
+        ]);
+        done();
+      });
     });
-  });
 
-  test('v2 -> hook -> query (text: string, values: List, callback: Function) -> fail', (done) => {
-    const error = new Error('DuumyError');
-    const client = createHookedMySqlV2Client({ error });
+    test('hook -> object query (text: string, callback: Function) -> success', (done) => {
+      const client = createHookedMySqlV2Client();
 
-    client.query('SELECT * from users', ['123'], () => {
-      const spans = SpansContainer.getSpans();
-      expect(spans).toEqual([
-        createBaseBuilderFromSpan(spans[0])
-          .withQuery('SELECT * from users')
-          .withConnectionParameters(DUMMY_OPTIONS)
-          .withValues(payloadStringify(['123']))
-          .withError(payloadStringify(error))
-          .build(),
-      ]);
-      done();
+      client.query({ sql: 'SELECT * from users' }, () => {
+        const spans = SpansContainer.getSpans();
+        expect(spans).toEqual([
+          createBaseBuilderFromSpan(spans[0])
+            .withQuery('SELECT * from users')
+            .withConnectionParameters(DUMMY_OPTIONS)
+            .withResponse(createExpectedResponse())
+            .build(),
+        ]);
+        done();
+      });
     });
-  });
 
-  test('v2 -> hook -> execute(text: string, callback: Function) -> success', (done) => {
-    const client = createHookedMySqlV2Client();
+    test('hook -> query (text: string, callback: Function) -> fail', (done) => {
+      const error = new Error('DuumyError');
+      const client = createHookedMySqlV2Client({ error });
 
-    client.execute('SELECT * from users', () => {
-      const spans = SpansContainer.getSpans();
-      expect(spans).toEqual([
-        createBaseBuilderFromSpan(spans[0])
-          .withQuery('SELECT * from users')
-          .withConnectionParameters(DUMMY_OPTIONS)
-          .withResponse(createExpectedResponse())
-          .build(),
-      ]);
-      done();
+      client.query('SELECT * from users', () => {
+        const spans = SpansContainer.getSpans();
+        expect(spans).toEqual([
+          createBaseBuilderFromSpan(spans[0])
+            .withQuery('SELECT * from users')
+            .withConnectionParameters(DUMMY_OPTIONS)
+            .withError(payloadStringify(error))
+            .build(),
+        ]);
+        done();
+      });
     });
-  });
 
-  test('v2 -> hook -> execute (text: string, values: List, callback: Function) -> success', (done) => {
-    const client = createHookedMySqlV2Client();
+    test('hook -> query (text: string, values: List, callback: Function) -> fail', (done) => {
+      const error = new Error('DuumyError');
+      const client = createHookedMySqlV2Client({ error });
 
-    client.execute('SELECT * from users', ['123'], () => {
-      const spans = SpansContainer.getSpans();
-      expect(spans).toEqual([
-        createBaseBuilderFromSpan(spans[0])
-          .withQuery('SELECT * from users')
-          .withConnectionParameters(DUMMY_OPTIONS)
-          .withValues(payloadStringify(['123']))
-          .withResponse(createExpectedResponse())
-          .build(),
-      ]);
-      done();
+      client.query('SELECT * from users', ['123'], () => {
+        const spans = SpansContainer.getSpans();
+        expect(spans).toEqual([
+          createBaseBuilderFromSpan(spans[0])
+            .withQuery('SELECT * from users')
+            .withConnectionParameters(DUMMY_OPTIONS)
+            .withValues(payloadStringify(['123']))
+            .withError(payloadStringify(error))
+            .build(),
+        ]);
+        done();
+      });
     });
-  });
 
-  test('v2 -> hook -> execute (text: string, callback: Function) -> fail', (done) => {
-    const error = new Error('DuumyError');
-    const client = createHookedMySqlV2Client({ error });
+    test('hook -> execute(text: string, callback: Function) -> success', (done) => {
+      const client = createHookedMySqlV2Client();
 
-    client.execute('SELECT * from users', () => {
-      const spans = SpansContainer.getSpans();
-      expect(spans).toEqual([
-        createBaseBuilderFromSpan(spans[0])
-          .withQuery('SELECT * from users')
-          .withConnectionParameters(DUMMY_OPTIONS)
-          .withError(payloadStringify(error))
-          .build(),
-      ]);
-      done();
+      client.execute('SELECT * from users', () => {
+        const spans = SpansContainer.getSpans();
+        expect(spans).toEqual([
+          createBaseBuilderFromSpan(spans[0])
+            .withQuery('SELECT * from users')
+            .withConnectionParameters(DUMMY_OPTIONS)
+            .withResponse(createExpectedResponse())
+            .build(),
+        ]);
+        done();
+      });
     });
-  });
 
-  test('v2 -> hook -> execute (text: string, values: List, callback: Function) -> fail', (done) => {
-    const error = new Error('DuumyError');
-    const client = createHookedMySqlV2Client({ error });
+    test('hook -> execute(text: string, arg: string, callback: Function) -> success', (done) => {
+      const client = createHookedMySqlV2Client();
 
-    client.execute('SELECT * from users', ['123'], () => {
-      const spans = SpansContainer.getSpans();
-      expect(spans).toEqual([
-        createBaseBuilderFromSpan(spans[0])
-          .withQuery('SELECT * from users')
-          .withConnectionParameters(DUMMY_OPTIONS)
-          .withValues(payloadStringify(['123']))
-          .withError(payloadStringify(error))
-          .build(),
-      ]);
-      done();
+      client.execute('SELECT * FROM data WHERE name = ?', 'Jeff', () => {
+        const spans = SpansContainer.getSpans();
+        expect(spans).toEqual([
+          createBaseBuilderFromSpan(spans[0])
+            .withQuery('SELECT * FROM data WHERE name = ?')
+            .withValues('"Jeff"')
+            .withConnectionParameters(DUMMY_OPTIONS)
+            .withResponse(createExpectedResponse())
+            .build(),
+        ]);
+        done();
+      });
     });
-  });
 
-  test('v1 -> hook -> query (text: string, callback: Function) -> success', (done) => {
-    const client = createHookedMySqlV1Client();
+    test('hook -> execute(text: string, args: Object, callback: Function) -> success', (done) => {
+      const client = createHookedMySqlV2Client();
 
-    client.query('SELECT * from users', () => {
-      const spans = SpansContainer.getSpans();
-      expect(spans).toEqual([
-        createBaseBuilderFromSpan(spans[0])
-          .withQuery('SELECT * from users')
-          .withConnectionParameters(DUMMY_OPTIONS)
-          .withResponse(createExpectedResponse())
-          .build(),
-      ]);
-      done();
+      client.execute(
+        'SELECT * FROM data WHERE name = ? AND surname = ?',
+        { name: 'Jeff', surname: 'Jeffity' },
+        () => {
+          const spans = SpansContainer.getSpans();
+          expect(spans).toEqual([
+            createBaseBuilderFromSpan(spans[0])
+              .withQuery('SELECT * FROM data WHERE name = ? AND surname = ?')
+              .withValues('{"name":"Jeff","surname":"Jeffity"}')
+              .withConnectionParameters(DUMMY_OPTIONS)
+              .withResponse(createExpectedResponse())
+              .build(),
+          ]);
+          done();
+        }
+      );
     });
-  });
 
-  test('v1 -> hook -> query (text: string, values: List, callback: Function) -> success', (done) => {
-    const client = createHookedMySqlV1Client();
+    test('hook -> execute (text: string, values: List, callback: Function) -> success', (done) => {
+      const client = createHookedMySqlV2Client();
 
-    client.query('SELECT * from users', ['123'], () => {
-      const spans = SpansContainer.getSpans();
-      expect(spans).toEqual([
-        createBaseBuilderFromSpan(spans[0])
-          .withQuery('SELECT * from users')
-          .withConnectionParameters(DUMMY_OPTIONS)
-          .withValues(payloadStringify(['123']))
-          .withResponse(createExpectedResponse())
-          .build(),
-      ]);
-      done();
+      client.execute('SELECT * from users', ['123'], () => {
+        const spans = SpansContainer.getSpans();
+        expect(spans).toEqual([
+          createBaseBuilderFromSpan(spans[0])
+            .withQuery('SELECT * from users')
+            .withConnectionParameters(DUMMY_OPTIONS)
+            .withValues(payloadStringify(['123']))
+            .withResponse(createExpectedResponse())
+            .build(),
+        ]);
+        done();
+      });
     });
-  });
 
-  test('v1 -> hook -> query (text: string, callback: Function) -> fail', (done) => {
-    const error = new Error('DuumyError');
-    const client = createHookedMySqlV1Client({ error });
+    test('hook -> execute (text: string, callback: Function) -> fail', (done) => {
+      const error = new Error('DuumyError');
+      const client = createHookedMySqlV2Client({ error });
 
-    client.query('SELECT * from users', () => {
-      const spans = SpansContainer.getSpans();
-      expect(spans).toEqual([
-        createBaseBuilderFromSpan(spans[0])
-          .withQuery('SELECT * from users')
-          .withConnectionParameters(DUMMY_OPTIONS)
-          .withError(payloadStringify(error))
-          .build(),
-      ]);
-      done();
+      client.execute('SELECT * from users', () => {
+        const spans = SpansContainer.getSpans();
+        expect(spans).toEqual([
+          createBaseBuilderFromSpan(spans[0])
+            .withQuery('SELECT * from users')
+            .withConnectionParameters(DUMMY_OPTIONS)
+            .withError(payloadStringify(error))
+            .build(),
+        ]);
+        done();
+      });
     });
-  });
 
-  test('v1 -> hook -> query (text: string, values: List, callback: Function) -> fail', (done) => {
-    const error = new Error('DuumyError');
-    const client = createHookedMySqlV1Client({ error });
+    test('hook -> execute (text: string, values: List, callback: Function) -> fail', (done) => {
+      const error = new Error('DuumyError');
+      const client = createHookedMySqlV2Client({ error });
 
-    client.query('SELECT * from users', ['123'], () => {
-      const spans = SpansContainer.getSpans();
-      expect(spans).toEqual([
-        createBaseBuilderFromSpan(spans[0])
-          .withQuery('SELECT * from users')
-          .withConnectionParameters(DUMMY_OPTIONS)
-          .withValues(payloadStringify(['123']))
-          .withError(payloadStringify(error))
-          .build(),
-      ]);
-      done();
+      client.execute('SELECT * from users', ['123'], () => {
+        const spans = SpansContainer.getSpans();
+        expect(spans).toEqual([
+          createBaseBuilderFromSpan(spans[0])
+            .withQuery('SELECT * from users')
+            .withConnectionParameters(DUMMY_OPTIONS)
+            .withValues(payloadStringify(['123']))
+            .withError(payloadStringify(error))
+            .build(),
+        ]);
+        done();
+      });
     });
   });
 });

--- a/src/hooks/mySql.test.js
+++ b/src/hooks/mySql.test.js
@@ -87,7 +87,7 @@ describe('mySql', () => {
     });
 
     test('hook -> query (text: string, callback: Function) -> fail', (done) => {
-      const error = new Error('DuumyError');
+      const error = new Error('DummyError');
       const client = createHookedMySqlV1Client({ error });
 
       client.query('SELECT * from users', () => {
@@ -104,7 +104,7 @@ describe('mySql', () => {
     });
 
     test('hook -> query (text: string, values: List, callback: Function) -> fail', (done) => {
-      const error = new Error('DuumyError');
+      const error = new Error('DummyError');
       const client = createHookedMySqlV1Client({ error });
 
       client.query('SELECT * from users', ['123'], () => {
@@ -246,7 +246,7 @@ describe('mySql', () => {
     });
 
     test('hook -> query (text: string, callback: Function) -> fail', (done) => {
-      const error = new Error('DuumyError');
+      const error = new Error('DummyError');
       const client = createHookedMySqlV2Client({ error });
 
       client.query('SELECT * from users', () => {
@@ -263,7 +263,7 @@ describe('mySql', () => {
     });
 
     test('hook -> query (text: string, values: List, callback: Function) -> fail', (done) => {
-      const error = new Error('DuumyError');
+      const error = new Error('DummyError');
       const client = createHookedMySqlV2Client({ error });
 
       client.query('SELECT * from users', ['123'], () => {
@@ -352,7 +352,7 @@ describe('mySql', () => {
     });
 
     test('hook -> execute (text: string, callback: Function) -> fail', (done) => {
-      const error = new Error('DuumyError');
+      const error = new Error('DummyError');
       const client = createHookedMySqlV2Client({ error });
 
       client.execute('SELECT * from users', () => {
@@ -369,7 +369,7 @@ describe('mySql', () => {
     });
 
     test('hook -> execute (text: string, values: List, callback: Function) -> fail', (done) => {
-      const error = new Error('DuumyError');
+      const error = new Error('DummyError');
       const client = createHookedMySqlV2Client({ error });
 
       client.execute('SELECT * from users', ['123'], () => {


### PR DESCRIPTION
Collect the values passed as named or unnamed parameters in to `mysql-2`'s `.query()` and `.execute()` for the following calling conventions:

* Values nested in `options` object: `client.query({ sql: 'SELECT * FROM users WHERE id = ?', values: ['123']}, callback?)`
* Single value: `client.query('SELECT * FROM users WHERE id = ?', '123', callback?)`
* Named parameters: `client.query('SELECT * FROM users WHERE id = ?id', {id: '123'}, callback?)`