### PR TITLE
feat: add support for .mjs, .cjs on Node.js 14+

### DIFF
--- a/scripts/bd_to_prod.sh
+++ b/scripts/bd_to_prod.sh
@@ -40,13 +40,11 @@ echo "Creating lumigo-node layer"
 
 echo "Creating layer latest version arn table md file (LAYERS.md)"
 cd ../larn && npm i -g
-larn -r nodejs10.x -n layers/LAYERS10x --filter lumigo-node-tracer -p ~/lumigo-node
 larn -r nodejs12.x -n layers/LAYERS12x --filter lumigo-node-tracer -p ~/lumigo-node
 larn -r nodejs14.x -n layers/LAYERS14x --filter lumigo-node-tracer -p ~/lumigo-node
 larn -r nodejs16.x -n layers/LAYERS16x --filter lumigo-node-tracer -p ~/lumigo-node
 larn -r nodejs18.x -n layers/LAYERS18x --filter lumigo-node-tracer -p ~/lumigo-node
 cd ../lumigo-node
-git add layers/LAYERS10x.md
 git add layers/LAYERS12x.md
 git add layers/LAYERS14x.md
 git add layers/LAYERS16x.md


### PR DESCRIPTION
This commit instrucing async + import loading paths to be used on Node.js 14+ runtimes, adding support for .mjs and .cjs files in the process.

Support for the Node.js 10.x runtime is no longer declared on the layer, as it is no longer supported by AWS itself and no new functions can be created with it.