### PR TITLE
fix: replace auto-instrument.handler with NODE_OPTIONS injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ You can read more about it [here](https://www.typescriptlang.org/tsconfig#esModu
 * `LUMIGO_DOMAINS_SCRUBBER='[".*secret.*"]'` - Prevents Lumigo from collecting both request and response details from a list of domains. This accepts a comma-separated list of regular expressions that is JSON-formatted. By default, the tracer uses `["secretsmanager\..*\.amazonaws\.com", "ssm\..*\.amazonaws\.com", "kms\..*\.amazonaws\.com"]`. **Note** - These defaults are overridden when you define a different list of regular expressions.
 * `LUMIGO_PROPAGATE_W3C=TRUE` - Add W3C TraceContext headers to outgoing HTTP requests. This enables uninterrupted transactions with applications traced with OpenTelemetry.
 * `LUMIGO_SWITCH_OFF=TRUE` - In the event a critical issue arises, this turns off all actions that Lumigo takes in response to your code. This happens without a deployment, and is picked up on the next function run once the environment variable is present.
+* `LUMIGO_NODE_OPTIONS_INJECTION=TRUE` - Uses the new `NODE_OPTIONS`-based method of activating the Lumigo tracer inside a Lambda layer. This option applies only to Lumigo tracer nodes delivered over the [Lumigo layers](./layers/). The previous method, using the [`auto-instrument-handler`](./auto-instrument-handler/) is known to have some corner-case issues in newer Node.js versions, but it is still available by setting `LUMIGO_NODE_OPTIONS_INJECTION=FALSE`.
 
 ### Step Functions
 

--- a/auto-instrument-handler/lumigo_wrapper
+++ b/auto-instrument-handler/lumigo_wrapper
@@ -6,13 +6,13 @@ shopt -s nocasematch
 
 function log {
     if [ "${LUMIGO_DEBUG}" = 'true' ]; then
-        echo "$1"
+        echo "#LUMIGO# $1"
     fi
 }
 
 # LUMIGO_NODE_OPTIONS_INJECTION has default true
 if [ "${LUMIGO_NODE_OPTIONS_INJECTION:-true}" = 'true' ]; then
-    log '#LUMIGO# Using NODE_OPTIONS-based injection'
+    log 'Using NODE_OPTIONS-based injection'
 
     # Add the `@lumigo/tracer` package as required via an additional
     # `--require/-r` command-line argument [1], added to the node runtime
@@ -23,7 +23,7 @@ if [ "${LUMIGO_NODE_OPTIONS_INJECTION:-true}" = 'true' ]; then
     new_node_options='-r @lumigo/tracer'
 
     if [ -n "${NODE_OPTIONS}" ]; then
-        log "#LUMIGO# Preserving pre-existing NODE_OPTIONS value: '${NODE_OPTIONS}'"
+        log "Preserving pre-existing NODE_OPTIONS value: '${NODE_OPTIONS}'"
     
         # Preserve existing Node options, prepending our require
         new_node_options="${new_node_options} ${NODE_OPTIONS}"
@@ -31,7 +31,7 @@ if [ "${LUMIGO_NODE_OPTIONS_INJECTION:-true}" = 'true' ]; then
 
     export NODE_OPTIONS="${new_node_options}"
 else
-    log "#LUMIGO# Using legacy 'lumigo-auto-instrument.handler' injection"
+    log "Using legacy 'lumigo-auto-instrument.handler' injection"
 
     export LUMIGO_ORIGINAL_HANDLER=$_HANDLER
     export _HANDLER="lumigo-auto-instrument.handler"

--- a/auto-instrument-handler/lumigo_wrapper
+++ b/auto-instrument-handler/lumigo_wrapper
@@ -1,5 +1,40 @@
 #!/bin/bash
 
-export LUMIGO_ORIGINAL_HANDLER=$_HANDLER
-export _HANDLER="lumigo-auto-instrument.handler"
+# Enable case-insentive match of vars
+# https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html
+shopt -s nocasematch
+
+function log {
+    if [ "${LUMIGO_DEBUG}" = 'true' ]; then
+        echo "$1"
+    fi
+}
+
+# LUMIGO_NODE_OPTIONS_INJECTION has default true
+if [ "${LUMIGO_NODE_OPTIONS_INJECTION:-true}" = 'true' ]; then
+    log '#LUMIGO# Using NODE_OPTIONS-based injection'
+
+    # Add the `@lumigo/tracer` package as required via an additional
+    # `--require/-r` command-line argument [1], added to the node runtime
+    # by means of the NODE_OPTIONS env var [2]
+    #
+    # [1] https://nodejs.org/api/cli.html#node_optionsoptions, since Node 1.6.0
+    # [2] https://nodejs.org/api/cli.html#node_optionsoptions, since Node 8.0
+    new_node_options='-r @lumigo/tracer'
+
+    if [ -n "${NODE_OPTIONS}" ]; then
+        log "#LUMIGO# Preserving pre-existing NODE_OPTIONS value: '${NODE_OPTIONS}'"
+    
+        # Preserve existing Node options, prepending our require
+        new_node_options="${new_node_options} ${NODE_OPTIONS}"
+    fi
+
+    export NODE_OPTIONS="${new_node_options}"
+else
+    log "#LUMIGO# Using legacy 'lumigo-auto-instrument.handler' injection"
+
+    export LUMIGO_ORIGINAL_HANDLER=$_HANDLER
+    export _HANDLER="lumigo-auto-instrument.handler"
+fi
+
 exec "$@"


### PR DESCRIPTION
The `auto-instrument.handler` has some issues related with complex CommonJS cases on Node.js 16+, and it is very hard to cover all the possible combinations of how Node.js modules of the function handler should be loaded [^1][^2] without breaking others.

Instead, this PR skips the entire auto-instrument.handler finicky thing, and introduces a simple NODE_OPTIONS based method inside the `AWS_LAMBDA_EXEC_WRAPPER`. The method is effectively the same we use with the Lumigo OpenTelemetry Distro for JS.

[^1] CommonJS: https://nodejs.org/api/modules.html
[^2] ESM: https://nodejs.org/api/esm.html