### PR TITLE
fix: split http instrumentation to core logic and http lib integration

### DIFF
--- a/src/hooks/baseHttp.test.js
+++ b/src/hooks/baseHttp.test.js
@@ -279,6 +279,7 @@ describe('http hook', () => {
     expect(BaseHttp._getHostFromOptionsOrUrl({ options: options2 })).toEqual('asdf2.com');
     expect(BaseHttp._getHostFromOptionsOrUrl({ options: options3 })).toEqual('asdf3.com');
     expect(BaseHttp._getHostFromOptionsOrUrl({ options: options4 })).toEqual('localhost');
+    expect(BaseHttp._getHostFromOptionsOrUrl({})).toEqual('localhost');
 
     const url1 = 'https://asdf.io:1234/yo?ref=baba';
     expect(BaseHttp._getHostFromOptionsOrUrl({ options: {}, url: url1 })).toEqual('asdf.io');

--- a/src/hooks/baseHttp.test.js
+++ b/src/hooks/baseHttp.test.js
@@ -1,0 +1,395 @@
+import MockDate from 'mockdate';
+import * as shimmer from 'shimmer';
+import { HttpsMocker } from '../../testUtils/httpsMocker';
+import { lowerCaseObjectKeys, LUMIGO_SECRET_MASKING_REGEX_HTTP_QUERY_PARAMS } from '../utils';
+
+import { TracerGlobals } from '../globals';
+import { BaseHttp } from './baseHttp';
+
+describe('http hook', () => {
+  process.env['AWS_REGION'] = 'us-east-x';
+  process.env['_X_AMZN_TRACE_ID'] =
+    'Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Parent=59fa1aeb03c2ec1f;Sampled=1';
+
+  const spies = {};
+  spies.shimmer = jest.spyOn(shimmer, 'wrap');
+
+  beforeEach(() => {
+    spies.shimmer.mockClear();
+    shimmer.unwrap(HttpsMocker, 'request');
+  });
+
+  test('isBlacklisted', () => {
+    const host = 'asdf';
+    const edgeHost = 'us-east-x.lumigo-tracer-edge.golumigo.com';
+    TracerGlobals.setTracerInputs({ ...TracerGlobals.getTracerInputs(), edgeHost });
+    expect(BaseHttp.isBlacklisted(host)).toBe(false);
+    expect(BaseHttp.isBlacklisted(edgeHost)).toBe(true);
+  });
+
+  test('aggregateRequestBodyToSpan ->  happy flow', () => {
+    const currentSpan = {
+      info: {
+        httpInfo: {},
+      },
+    };
+    BaseHttp.aggregateRequestBodyToSpan(
+      'a',
+      {
+        body: 'a',
+        host: 'host',
+      },
+      currentSpan
+    );
+    expect(currentSpan).toEqual({
+      info: {
+        httpInfo: {
+          host: 'host',
+          request: {
+            body: 'aa',
+            host: 'host',
+            truncated: false,
+          },
+          response: {},
+        },
+      },
+    });
+  });
+
+  test('aggregateRequestBodyToSpan ->  missing resource name on span and adding it on end event', () => {
+    const currentSpan = {
+      info: {
+        resourceName: '',
+        httpInfo: {},
+      },
+    };
+    BaseHttp.aggregateRequestBodyToSpan(
+      ',"Item":{"id":{"S":"5590.195458064029"},"message":{"S":"DummyMessage"}}}',
+      {
+        truncated: false,
+        uri: 'dynamodb.us-east-1.amazonaws.com/',
+        host: 'dynamodb.us-east-1.amazonaws.com',
+        headers: {
+          'x-amz-target': 'DynamoDB_20120810.PutItem',
+          host: 'dynamodb.us-east-1.amazonaws.com',
+        },
+        body: '{"TableName":"test-table"',
+      },
+      currentSpan
+    );
+    expect(currentSpan).toEqual({
+      info: {
+        resourceName: 'test-table',
+        httpInfo: {
+          host: 'dynamodb.us-east-1.amazonaws.com',
+          request: {
+            truncated: false,
+            uri: 'dynamodb.us-east-1.amazonaws.com/',
+            host: 'dynamodb.us-east-1.amazonaws.com',
+            headers: {
+              'x-amz-target': 'DynamoDB_20120810.PutItem',
+              host: 'dynamodb.us-east-1.amazonaws.com',
+            },
+            body: '{"TableName":"test-table","Item":{"id":{"S":"5590.195458064029"},"message":{"S":"DummyMessage"}}}',
+          },
+          response: {},
+        },
+        dynamodbMethod: 'PutItem',
+        messageId: '546fb5c2a83410ebeba6a7c9b1324a04',
+      },
+    });
+  });
+
+  test('aggregateRequestBodyToSpan ->  should truncate body', () => {
+    const currentSpan = {
+      info: {
+        httpInfo: {},
+      },
+    };
+    BaseHttp.aggregateRequestBodyToSpan(
+      'a',
+      {
+        body: 'a',
+        host: 'host',
+      },
+      currentSpan,
+      1
+    );
+    expect(currentSpan).toEqual({
+      info: {
+        httpInfo: {
+          host: 'host',
+          request: {
+            body: 'a',
+            host: 'host',
+            truncated: true,
+          },
+          response: {},
+        },
+      },
+    });
+  });
+
+  test('aggregateRequestBodyToSpan ->  already truncated', () => {
+    const currentSpan = {
+      info: {
+        httpInfo: {},
+      },
+    };
+    BaseHttp.aggregateRequestBodyToSpan(
+      'a',
+      {
+        body: 'a',
+        host: 'host',
+        truncated: true,
+      },
+      currentSpan,
+      100
+    );
+    expect(currentSpan).toEqual({
+      info: {
+        httpInfo: {
+          host: 'host',
+          request: {
+            body: 'a',
+            host: 'host',
+            truncated: true,
+          },
+          response: {},
+        },
+      },
+    });
+  });
+
+  test('httpRequestWriteBeforeHookWrapper -> simple flow -> write(str)', () => {
+    const requestData = {
+      body: '',
+    };
+
+    const firstArg = 'BODY';
+
+    const wrapper = BaseHttp.createRequestDataWriteHandler({ requestData });
+    wrapper([firstArg]);
+
+    expect(requestData).toEqual({ body: 'BODY', truncated: false });
+  });
+
+  test('httpRequestWriteBeforeHookWrapper -> simple flow -> write(Buffer)', () => {
+    const requestData = {
+      body: '',
+    };
+    const wrapper = BaseHttp.createRequestDataWriteHandler({ requestData });
+    const firstArg = Buffer.from('BODY');
+
+    wrapper([firstArg]);
+
+    expect(requestData).toEqual({ body: 'BODY', truncated: false });
+  });
+
+  test('httpRequestWriteBeforeHookWrapper -> simple flow -> write(Buffer, encoding)', () => {
+    const requestData = {
+      body: '',
+    };
+
+    const firstArg = 'BODY';
+    const secArg = 'base64';
+
+    const wrapper = BaseHttp.createRequestDataWriteHandler({ requestData });
+    wrapper([firstArg, secArg]);
+
+    expect(requestData).toEqual({ body: 'Qk9EWQ==', truncated: false });
+  });
+
+  test('httpRequestWriteBeforeHookWrapper -> simple flow -> write(Buffer, encoding, callback)', () => {
+    const requestData = {
+      body: '',
+    };
+
+    const firstArg = Buffer.from('BODY');
+    const secArg = 'utf8';
+    const thirdArg = () => {};
+
+    const wrapper = BaseHttp.createRequestDataWriteHandler({ requestData });
+    wrapper([firstArg, secArg, thirdArg]);
+
+    expect(requestData).toEqual({ body: 'BODY', truncated: false });
+  });
+
+  test('httpRequestWriteBeforeHookWrapper -> simple flow -> write(Buffer, callback)', () => {
+    const requestData = {
+      body: '',
+    };
+
+    const firstArg = Buffer.from('BODY');
+    const secArg = () => {};
+
+    const wrapper = BaseHttp.createRequestDataWriteHandler({ requestData });
+    wrapper([firstArg, secArg]);
+
+    expect(requestData).toEqual({ body: 'BODY', truncated: false });
+  });
+
+  test('httpRequestWriteBeforeHookWrapper -> simple flow -> write(str, callback)', () => {
+    const requestData = {
+      body: '',
+    };
+
+    const firstArg = 'BODY';
+    const secArg = () => {};
+
+    const wrapper = BaseHttp.createRequestDataWriteHandler({ requestData });
+    wrapper([firstArg, secArg]);
+
+    expect(requestData).toEqual({ body: 'BODY', truncated: false });
+  });
+
+  test('httpRequestWriteBeforeHookWrapper -> not override body', () => {
+    const requestData = {
+      body: 'BODY1',
+    };
+
+    const firstArg = Buffer.from('BODY2');
+
+    const wrapper = BaseHttp.createRequestDataWriteHandler({ requestData });
+    wrapper([firstArg]);
+
+    expect(requestData).toEqual({ body: 'BODY1' });
+  });
+
+  test('httpRequestWriteBeforeHookWrapper -> not crashed on bad data', () => {
+    const requestData = {
+      body: '',
+    };
+
+    const firstArg = {};
+    const secArg = {};
+
+    const wrapper = BaseHttp.createRequestDataWriteHandler({ requestData });
+    wrapper(firstArg, secArg);
+
+    expect(requestData).toEqual({ body: '' });
+  });
+
+  test('getHostFromOptionsOrUrl', () => {
+    const options1 = { host: 'asdf1.com' };
+    const options2 = { hostname: 'asdf2.com' };
+    const options3 = { uri: { hostname: 'asdf3.com' } };
+    const options4 = {};
+    expect(BaseHttp._getHostFromOptionsOrUrl({ options: options1 })).toEqual('asdf1.com');
+    expect(BaseHttp._getHostFromOptionsOrUrl({ options: options2 })).toEqual('asdf2.com');
+    expect(BaseHttp._getHostFromOptionsOrUrl({ options: options3 })).toEqual('asdf3.com');
+    expect(BaseHttp._getHostFromOptionsOrUrl({ options: options4 })).toEqual('localhost');
+
+    const url1 = 'https://asdf.io:1234/yo?ref=baba';
+    expect(BaseHttp._getHostFromOptionsOrUrl({ options: {}, url: url1 })).toEqual('asdf.io');
+  });
+
+  test('parseHttpRequestOptions', () => {
+    const headers = { X: 'Y', Z: 'A' };
+    const options1 = {
+      host: 'asdf1.com',
+      port: 443,
+      protocol: 'https:',
+      path: '/api/where/is/satoshi',
+      method: 'POST',
+      headers,
+    };
+    const sendTime = 895179612345;
+    MockDate.set(sendTime);
+
+    const expectedHeaders = lowerCaseObjectKeys({
+      ...headers,
+      ...{ host: 'asdf1.com' },
+    });
+
+    const expected1 = {
+      host: 'asdf1.com',
+      port: 443,
+      protocol: 'https:',
+      path: '/api/where/is/satoshi',
+      uri: 'asdf1.com/api/where/is/satoshi',
+      method: 'POST',
+      truncated: false,
+      headers: expectedHeaders,
+      sendTime,
+      body: '',
+    };
+    expect(BaseHttp.parseHttpRequestOptions(options1)).toEqual(expected1);
+
+    const url2 = 'https://asdf.io:1234/yo.php?ref=baba';
+    const options2 = { headers, method: 'POST' };
+    const expected2 = {
+      body: '',
+      headers: {
+        x: 'Y',
+        z: 'A',
+        host: 'asdf.io',
+      },
+      host: 'asdf.io',
+      method: 'POST',
+      path: '/yo.php',
+      truncated: false,
+      uri: 'asdf.io/yo.php?ref=baba',
+      port: '1234',
+      protocol: 'https:',
+      sendTime: 895179612345,
+    };
+
+    expect(BaseHttp.parseHttpRequestOptions(options2, url2)).toEqual(expected2);
+  });
+
+  test('parseHttpRequestOptions - scrub query params', () => {
+    const sendTime = 895179612345;
+    MockDate.set(sendTime);
+
+    const headers = { X: 'Y', Z: 'A' };
+
+    const url2 = 'https://asdf.io:1234/yo.php?ref=baba&password=1234';
+    const options2 = { headers, method: 'POST' };
+    const expected2 = {
+      body: '',
+      headers: {
+        x: 'Y',
+        z: 'A',
+        host: 'asdf.io',
+      },
+      host: 'asdf.io',
+      method: 'POST',
+      path: '/yo.php',
+      truncated: false,
+      uri: 'asdf.io/yo.php?ref=baba&password=****',
+      port: '1234',
+      protocol: 'https:',
+      sendTime: 895179612345,
+    };
+
+    expect(BaseHttp.parseHttpRequestOptions(options2, url2)).toEqual(expected2);
+  });
+
+  test('httpRequestEndWrapper', () => {
+    const body = 'abcdefg';
+    const requestData = { body: '' };
+
+    const data = body;
+    const encoding = 'utf8';
+    const callback = jest.fn();
+    BaseHttp.createRequestDataWriteHandler({ requestData })([data, encoding, callback]);
+
+    expect(requestData).toEqual({ body: body, truncated: false });
+  });
+
+  test('scrubQueryParams', () => {
+    expect(BaseHttp.scrubQueryParams('?password=123')).toEqual('?password=****');
+    expect(BaseHttp.scrubQueryParams('?plain=123')).toEqual('?plain=123');
+    expect(BaseHttp.scrubQueryParams('?password=123&plain=123')).toEqual(
+      '?password=****&plain=123'
+    );
+    expect(BaseHttp.scrubQueryParams('?password=123&plain=123&secret=123')).toEqual(
+      '?password=****&plain=123&secret=****'
+    );
+    process.env[LUMIGO_SECRET_MASKING_REGEX_HTTP_QUERY_PARAMS] = '["plain"]';
+    expect(BaseHttp.scrubQueryParams('?plain=123&bla=123')).toEqual('?plain=****&bla=123');
+
+    expect(BaseHttp.scrubQueryParams(1234)).toEqual('');
+  });
+});

--- a/src/hooks/baseHttp.ts
+++ b/src/hooks/baseHttp.ts
@@ -59,7 +59,6 @@ type HttpRequestTracingConfig = {
 export type ParseHttpRequestOptions = {
   agent?: Agent;
   _defaultAgent?: Agent;
-  // eslint-disable-next-line no-undef
   headers?: Record<string, string>;
   method?: 'GET' | 'POST';
   protocol?: string;

--- a/src/hooks/baseHttp.ts
+++ b/src/hooks/baseHttp.ts
@@ -1,0 +1,390 @@
+import { SpansContainer, TracerGlobals } from '../globals';
+import {
+  getCurrentTransactionId,
+  getHttpInfo,
+  getHttpSpan,
+  getServiceData,
+  ServiceData,
+} from '../spans/awsSpan';
+import {
+  addHeaders,
+  getAWSEnvironment,
+  getEdgeHost,
+  getEventEntitySize,
+  getPatchedTraceId,
+  getRandomId,
+  isAwsService,
+  isEmptyString,
+  isKeepHeadersOn,
+  isTimeoutTimerEnabled,
+  isValidAlias,
+  lowerCaseObjectKeys,
+  safeExecute,
+  shouldPropagateW3C,
+} from '../utils';
+import { GlobalDurationTimer } from '../utils/globalDurationTimer';
+import * as logger from '../logger';
+import { BasicChildSpan } from '../types/spans/basicSpan';
+import { getW3CTracerPropagatorAdditionalHeaders } from '../utils/w3cUtils';
+import {
+  extractBodyFromEmitSocketEvent,
+  extractBodyFromWriteOrEndFunc,
+  httpDataToString,
+} from './httpUtils';
+import { URL } from 'url';
+import { parse as parseQuery } from 'querystring';
+import { shallowMask } from '../utils/payloadStringify';
+import { Agent } from './http';
+
+export const hostBlaclist = new Set(['127.0.0.1']);
+
+type HttpRequestTracingConfig = {
+  // Headers of the request, including user defined headers & added headers
+  headers?: {};
+
+  // Headers added to the original headers
+  addedHeaders?: {};
+
+  // The HTTP span that was created for this request (Will be updated in place in the request response lifecycle)
+  httpSpan?: BasicChildSpan;
+
+  requestData?: { body: string };
+
+  requestRandomId?: string;
+
+  awsRequestId?: string;
+  transactionId?: string;
+};
+
+export type ParseHttpRequestOptions = {
+  agent?: Agent;
+  _defaultAgent?: Agent;
+  // eslint-disable-next-line no-undef
+  headers?: Record<string, string>;
+  method?: 'GET' | 'POST';
+  protocol?: string;
+  path?: string;
+  port?: number;
+  defaultPort?: number;
+  hostname?: string;
+  host?: string;
+  uri?: { hostname?: string };
+};
+
+export class BaseHttp {
+  /**
+   * Starts an HTTP request tracing span
+   * @param {ParseHttpRequestOptions} options Parameters about the new http request that is being triggered
+   * @param {string} url The URL of the new http request that is being triggered
+   * @returns {HttpRequestTracingConfig} The newly created span, and information required for altering the http request
+   */
+  static onRequestCreated({
+    options,
+    url,
+  }: {
+    options: ParseHttpRequestOptions;
+    url: string;
+  }): HttpRequestTracingConfig {
+    // Gather basic info for creating the HTTP span
+    const host = BaseHttp._getHostFromOptionsOrUrl({ options, url });
+    const headers = options.headers || {};
+    const addedHeaders = {};
+    const { awsRequestId } = TracerGlobals.getHandlerInputs().context;
+    const transactionId = getCurrentTransactionId();
+    const requestRandomId = getRandomId();
+
+    const shouldIgnoreReq =
+      BaseHttp.isBlacklisted(host) || !isValidAlias() || GlobalDurationTimer.isTimePassed();
+    if (shouldIgnoreReq) {
+      return {};
+    }
+
+    logger.debug('Starting hook', { host, url, headers });
+
+    const isRequestToAwsService = isAwsService(host);
+    if (isRequestToAwsService && !isKeepHeadersOn()) {
+      const { awsXAmznTraceId } = getAWSEnvironment();
+      addedHeaders['X-Amzn-Trace-Id'] = getPatchedTraceId(awsXAmznTraceId);
+      Object.assign(headers, addedHeaders);
+    }
+
+    if (shouldPropagateW3C()) {
+      safeExecute(() => {
+        Object.assign(addedHeaders, getW3CTracerPropagatorAdditionalHeaders(headers));
+      })();
+      Object.assign(headers, addedHeaders);
+    }
+
+    const requestData = BaseHttp.parseHttpRequestOptions(options, url);
+
+    if (isTimeoutTimerEnabled()) {
+      const httpSpan = getHttpSpan(transactionId, awsRequestId, requestRandomId, {
+        headers,
+      });
+      SpansContainer.addSpan(httpSpan);
+      return {
+        httpSpan,
+        addedHeaders,
+        headers,
+        requestData,
+        requestRandomId,
+        awsRequestId,
+        transactionId,
+      };
+    }
+    return {};
+  }
+
+  static _getHostFromOptionsOrUrl({
+    options,
+    url = undefined,
+  }: {
+    options?: ParseHttpRequestOptions;
+    url?: string;
+  }) {
+    if (url) {
+      return new URL(url).hostname;
+    }
+    if (options) {
+      return (
+        options.hostname || options.host || (options.uri && options.uri.hostname) || 'localhost'
+      );
+    }
+
+    return 'localhost';
+  }
+
+  // static createSendRequestDataHandler({
+  //   requestData,
+  //   currentSpan,
+  // }: {
+  //   requestData: { body: string };
+  //   currentSpan: BasicChildSpan;
+  // }) {
+  //   return function (data: Object, encoding: string) {
+  //     GlobalDurationTimer.start();
+  //     if (isEmptyString(requestData.body)) {
+  //       const body = extractBodyFromWriteOrEndFunc(args);
+  //       Http.aggregateRequestBodyToSpan(body, requestData, currentSpan, getEventEntitySize(true));
+  //     }
+  //     GlobalDurationTimer.stop();
+  //   };
+  // }
+
+  /**
+   * Returns a handler that should be called every time request body data is sent to the server.
+   * This handler will collect the request body and add it to the current span.
+   * @param {{body: string}} requestData The request data object that will be updated with the request body in place
+   * @param {BasicChildSpan} currentSpan The span of the current HTTP request, will be updated in place
+   * @returns {(args: any[]) => void} A handler that should be called everytime request body data is sent to the server,
+   *  with a list of arguments. The handler will update the current span with the new request data.
+   *  The input arguments are (by index):
+   *  [0] - The data that was sent, can be a string, buffer or any other type that can be converted to a string.
+   *  [1] - The encoding of the data, default is 'utf8' if no encoding / unknown encoding is given.
+   */
+  static createRequestDataWriteHandler({
+    requestData,
+    currentSpan = undefined,
+  }: {
+    requestData: { body: string };
+    currentSpan?: BasicChildSpan;
+  }): Function {
+    return function (args: any[]) {
+      GlobalDurationTimer.start();
+
+      // If we already loaded the body / part of it we don't want to load it again (The first chunk is enough for us)
+      if (isEmptyString(requestData.body)) {
+        const body = extractBodyFromWriteOrEndFunc(args);
+        BaseHttp.aggregateRequestBodyToSpan(
+          body,
+          requestData,
+          currentSpan,
+          getEventEntitySize(true)
+        );
+      }
+      GlobalDurationTimer.stop();
+    };
+  }
+
+  /**
+   * Returns a handler that should be called every time request body data is sent to the server,
+   * in cases where the data is written on the socket level.
+   * @param {{body: string}} requestData The request data object that will be updated with the request body in place
+   * @param {BasicChildSpan} currentSpan The span of the current HTTP request, will be updated in place
+   * @returns {Function} A handler that should be called everytime request body data is sent to the server,
+   *  with a list of arguments. The handler will update the current span with the new request data.
+   *  The input is a docket event object.
+   */
+  static createRequestSocketDataWriteHandler({
+    requestData,
+    currentSpan = undefined,
+  }: {
+    requestData: { body: string };
+    currentSpan?: BasicChildSpan;
+  }): Function {
+    return function (socketEventArgs: {}) {
+      GlobalDurationTimer.start();
+      if (isEmptyString(requestData.body)) {
+        const body = extractBodyFromEmitSocketEvent(socketEventArgs);
+        BaseHttp.aggregateRequestBodyToSpan(
+          body,
+          requestData,
+          currentSpan,
+          getEventEntitySize(true)
+        );
+      }
+      GlobalDurationTimer.stop();
+    };
+  }
+
+  /**
+   * Returns a handler that should be called every time response data is received from the server.
+   * This handler will collect the response data and add it to a new span once all the response data is received.
+   * @param {string} transactionId The current transaction id
+   * @param {string} awsRequestId The current AWS request id
+   * @param {{body: string}} requestData The current request data. Will be updated in place when the http span is finalized.
+   * @param {string} requestRandomId IDK
+   * @param {{headers: {}, statusCode: number}} response Details about the http response. Will be updated in place.
+   * @returns {(args: any[]) => void} Handler that should be called every time response data is received from the server.
+   *  The handler will update the current request data with the response data and create a new span for the response.
+   *  The input arguments are (by index):
+   *  [0] - The type of the response data, can be 'data' (loading a data chunk from the response) or 'end' (finished loading all response data chunks).
+   *  [1] - The data that was received, can be a string, buffer or any other type that can be converted to a string.
+   */
+  static createResponseDataWriterHandler({
+    transactionId,
+    awsRequestId,
+    requestData,
+    requestRandomId,
+    response,
+  }: {
+    transactionId: string;
+    awsRequestId: string;
+    requestData: { body: string };
+    requestRandomId: string;
+    response: { headers: {}; statusCode: number };
+  }): (args: any[]) => void {
+    let body = '';
+    const { headers, statusCode } = response;
+    const maxPayloadSize = getEventEntitySize(statusCode >= 400);
+    return function (args: any[]) {
+      GlobalDurationTimer.start();
+      const receivedTime = new Date().getTime();
+      let truncated = false;
+      // add to body only if we didn't pass the max size
+      if (args[0] === 'data' && body.length < maxPayloadSize) {
+        let chunk = httpDataToString(args[1]);
+        const allowedLengthToAdd = maxPayloadSize - body.length;
+        //if we reached or close to limit get only substring of the part to reach the limit
+        if (chunk.length > allowedLengthToAdd) {
+          truncated = true;
+          chunk = chunk.substr(0, allowedLengthToAdd);
+        }
+        body += chunk;
+      }
+      if (args[0] === 'end') {
+        const responseData = {
+          statusCode,
+          receivedTime,
+          body,
+          headers: lowerCaseObjectKeys(headers),
+        };
+        const httpSpan = getHttpSpan(
+          transactionId,
+          awsRequestId,
+          requestRandomId,
+          requestData,
+          Object.assign({ truncated }, responseData)
+        );
+        if (httpSpan.id !== requestRandomId) {
+          // In Http case, one of our parser decide to change the spanId for async connection
+          SpansContainer.changeSpanId(requestRandomId, httpSpan.id);
+        }
+        SpansContainer.addSpan(httpSpan);
+      }
+      GlobalDurationTimer.stop();
+    };
+  }
+
+  static isBlacklisted(host: string) {
+    return host === getEdgeHost() || hostBlaclist.has(host);
+  }
+
+  static aggregateRequestBodyToSpan(
+    body,
+    requestData,
+    currentSpan,
+    maxSize = getEventEntitySize(true)
+  ) {
+    let serviceData: ServiceData = {};
+    if (body && !requestData.truncated) {
+      requestData.body += body;
+      serviceData = getServiceData(requestData, null);
+      const truncated = maxSize < requestData.body.length;
+      if (truncated) requestData.body = requestData.body.substr(0, maxSize);
+      requestData.truncated = truncated;
+    }
+    if (currentSpan) {
+      currentSpan.info.httpInfo = getHttpInfo(requestData, {});
+      Object.assign(currentSpan.info, {
+        ...serviceData.awsServiceData,
+      });
+    }
+  }
+
+  @GlobalDurationTimer.timedSync()
+  static parseHttpRequestOptions(options: ParseHttpRequestOptions = {}, url?: string) {
+    const host = BaseHttp._getHostFromOptionsOrUrl({ options, url });
+    const agent = options.agent || options._defaultAgent;
+
+    let path = null;
+    let port = null;
+    let search = null;
+    let protocol = null;
+
+    const { headers, method = 'GET' } = options;
+    const sendTime = new Date().getTime();
+
+    if (url) {
+      const myUrl = new URL(url);
+      ({ pathname: path, port, protocol, search } = myUrl);
+    } else {
+      path = options.path || '/';
+      port = options.port || options.defaultPort || (agent && agent.defaultPort) || 80;
+      protocol = options.protocol || (port === 443 && 'https:') || 'http:';
+    }
+
+    const modifiedHeaders = headers && !headers.host ? addHeaders(headers, { host }) : headers;
+
+    if (!!search) {
+      search = BaseHttp.scrubQueryParams(search);
+    } else {
+      search = '';
+    }
+
+    const uri = `${host}${path}${search}`;
+
+    return {
+      truncated: false,
+      path,
+      port,
+      uri,
+      host,
+      body: '', // XXX Filled by the httpRequestEndWrapper or httpRequestEmitBeforeHookWrapper ( / Write)
+      method,
+      headers: lowerCaseObjectKeys(modifiedHeaders),
+      protocol,
+      sendTime,
+    };
+  }
+
+  static scrubQueryParams(search: string): string {
+    return (
+      safeExecute(() => {
+        const query = parseQuery(search.substring(1));
+        const scrubbedQuery = shallowMask('queryParams', query);
+        return '?' + new URLSearchParams(scrubbedQuery);
+      })() || ''
+    );
+  }
+}

--- a/src/hooks/baseHttp.ts
+++ b/src/hooks/baseHttp.ts
@@ -147,6 +147,7 @@ export class BaseHttp {
     return returnData;
   }
 
+  @GlobalDurationTimer.timedSync()
   static _getHostFromOptionsOrUrl({
     options,
     url = undefined,

--- a/src/hooks/baseHttp.ts
+++ b/src/hooks/baseHttp.ts
@@ -320,6 +320,7 @@ export class BaseHttp {
       requestData.truncated = truncated;
     }
     if (currentSpan) {
+      // @ts-ignore
       currentSpan.info.httpInfo = getHttpInfo(requestData, {});
       Object.assign(currentSpan.info, {
         ...serviceData.awsServiceData,

--- a/src/hooks/baseHttp.ts
+++ b/src/hooks/baseHttp.ts
@@ -166,23 +166,6 @@ export class BaseHttp {
     return 'localhost';
   }
 
-  // static createSendRequestDataHandler({
-  //   requestData,
-  //   currentSpan,
-  // }: {
-  //   requestData: { body: string };
-  //   currentSpan: BasicChildSpan;
-  // }) {
-  //   return function (data: Object, encoding: string) {
-  //     GlobalDurationTimer.start();
-  //     if (isEmptyString(requestData.body)) {
-  //       const body = extractBodyFromWriteOrEndFunc(args);
-  //       Http.aggregateRequestBodyToSpan(body, requestData, currentSpan, getEventEntitySize(true));
-  //     }
-  //     GlobalDurationTimer.stop();
-  //   };
-  // }
-
   /**
    * Returns a handler that should be called every time request body data is sent to the server.
    * This handler will collect the request body and add it to the current span.
@@ -198,7 +181,7 @@ export class BaseHttp {
     requestData,
     currentSpan = undefined,
   }: {
-    requestData: { body: string };
+    requestData: RequestData;
     currentSpan?: BasicChildSpan;
   }): Function {
     return function (args: any[]) {
@@ -231,7 +214,7 @@ export class BaseHttp {
     requestData,
     currentSpan = undefined,
   }: {
-    requestData: { body: string };
+    requestData: RequestData;
     currentSpan?: BasicChildSpan;
   }): Function {
     return function (socketEventArgs: {}) {
@@ -324,9 +307,9 @@ export class BaseHttp {
 
   static aggregateRequestBodyToSpan(
     body,
-    requestData,
-    currentSpan,
-    maxSize = getEventEntitySize(true)
+    requestData: RequestData,
+    currentSpan: BasicChildSpan,
+    maxSize: number = getEventEntitySize(true)
   ) {
     let serviceData: ServiceData = {};
     if (body && !requestData.truncated) {

--- a/src/hooks/baseHttp.ts
+++ b/src/hooks/baseHttp.ts
@@ -125,14 +125,17 @@ export class BaseHttp {
     if (isRequestToAwsService && !isKeepHeadersOn()) {
       const { awsXAmznTraceId } = getAWSEnvironment();
       addedHeaders['X-Amzn-Trace-Id'] = getPatchedTraceId(awsXAmznTraceId);
-      Object.assign(headers, addedHeaders);
     }
 
     if (shouldPropagateW3C()) {
       safeExecute(() => {
         Object.assign(addedHeaders, getW3CTracerPropagatorAdditionalHeaders(headers));
       })();
+    }
+
+    if (addedHeaders) {
       Object.assign(headers, addedHeaders);
+      options.headers = headers;
     }
 
     const requestData = BaseHttp.parseHttpRequestOptions(options, url);

--- a/src/hooks/baseHttp.ts
+++ b/src/hooks/baseHttp.ts
@@ -36,7 +36,7 @@ import { parse as parseQuery } from 'querystring';
 import { shallowMask } from '../utils/payloadStringify';
 import { Agent } from './http';
 
-export const hostBlaclist = new Set(['127.0.0.1']);
+export const hostBlacklist = new Set(['127.0.0.1']);
 
 type HttpRequestTracingConfig = {
   // Headers of the request, including user defined headers & added headers
@@ -303,7 +303,7 @@ export class BaseHttp {
   }
 
   static isBlacklisted(host: string) {
-    return host === getEdgeHost() || hostBlaclist.has(host);
+    return host === getEdgeHost() || hostBlacklist.has(host);
   }
 
   static aggregateRequestBodyToSpan(

--- a/src/hooks/baseHttp.ts
+++ b/src/hooks/baseHttp.ts
@@ -366,7 +366,7 @@ export class BaseHttp {
       port,
       uri,
       host,
-      body: '', // XXX Filled by the httpRequestEndWrapper or httpRequestEmitBeforeHookWrapper ( / Write)
+      body: '', // Filled by the httpRequestEndWrapper or httpRequestEmitBeforeHookWrapper ( / Write)
       method,
       headers: lowerCaseObjectKeys(modifiedHeaders),
       protocol,

--- a/src/hooks/baseHttp.ts
+++ b/src/hooks/baseHttp.ts
@@ -48,7 +48,7 @@ type HttpRequestTracingConfig = {
   // The HTTP span that was created for this request (Will be updated in place in the request response lifecycle)
   httpSpan?: BasicChildSpan;
 
-  requestData?: { body: string };
+  requestData?: RequestData;
 
   requestRandomId: string;
 
@@ -72,16 +72,16 @@ export type ParseHttpRequestOptions = {
 };
 
 export type RequestData = {
-  host: string;
-  body: any;
-  headers: any;
-  path: string;
-  truncated: boolean;
-  port: number;
-  uri: string;
-  method: string;
-  protocol: string;
-  sendTime: number;
+  host?: string;
+  body?: any;
+  headers?: any;
+  path?: string;
+  truncated?: boolean;
+  port?: number;
+  uri?: string;
+  method?: string;
+  protocol?: string;
+  sendTime?: number;
 };
 
 export class BaseHttp {

--- a/src/hooks/http.ts
+++ b/src/hooks/http.ts
@@ -57,13 +57,6 @@ export class Http {
     }
     return { url, options, callback };
   }
-  @GlobalDurationTimer.timedSync()
-  static getHostFromOptionsOrUrl(options, url) {
-    if (url) {
-      return new URL(url).hostname;
-    }
-    return options.hostname || options.host || (options.uri && options.uri.hostname) || 'localhost';
-  }
 
   static addOptionsToHttpRequestArguments(originalArgs, newOptions) {
     // We're switching on the different signatures of http:

--- a/src/hooks/http.ts
+++ b/src/hooks/http.ts
@@ -1,99 +1,34 @@
-import {
-  addHeaders,
-  getAWSEnvironment,
-  getEdgeHost,
-  getEventEntitySize,
-  getPatchedTraceId,
-  getRandomId,
-  isAwsService,
-  isEmptyString,
-  isKeepHeadersOn,
-  isTimeoutTimerEnabled,
-  isValidAlias,
-  lowerCaseObjectKeys,
-  safeExecute,
-  shouldPropagateW3C,
-} from '../utils';
-import {
-  extractBodyFromEmitSocketEvent,
-  extractBodyFromWriteOrEndFunc,
-  httpDataToString,
-} from './httpUtils';
-import {
-  ServiceData,
-  getServiceData,
-  getCurrentTransactionId,
-  getHttpInfo,
-  getHttpSpan,
-} from '../spans/awsSpan';
+import { getCurrentTransactionId, getHttpSpan } from '../spans/awsSpan';
 import { URL } from 'url';
 import { SpansContainer, TracerGlobals } from '../globals';
-import * as logger from '../logger';
 
 import * as extender from '../extender';
 import * as http from 'http';
 import * as https from 'https';
-const { parse: parseQuery } = require('querystring');
 
 import { GlobalDurationTimer } from '../utils/globalDurationTimer';
 import { runOneTimeWrapper } from '../utils/functionUtils';
-import { addW3CTracePropagator } from '../utils/w3cUtils';
-import { shallowMask } from '../utils/payloadStringify';
-
-export const hostBlaclist = new Set(['127.0.0.1']);
+import { BaseHttp } from './baseHttp';
+import { BasicChildSpan } from '../types/spans/basicSpan';
 
 export type Agent = {
   defaultPort: number;
 };
 
-export type ParseHttpRequestOptions = {
-  agent?: Agent;
-  _defaultAgent?: Agent;
-  // eslint-disable-next-line no-undef
-  headers?: Record<string, string>;
-  method?: 'GET' | 'POST';
-  protocol?: string;
-  path?: string;
-  port?: number;
-  defaultPort?: number;
-};
-
 export class Http {
-  static httpRequestEndWrapper(requestData, currentSpan) {
-    return function (args) {
-      GlobalDurationTimer.start();
-      if (isEmptyString(requestData.body)) {
-        const body = extractBodyFromWriteOrEndFunc(args);
-        Http.aggregateRequestBodyToSpan(body, requestData, currentSpan, getEventEntitySize(true));
-      }
-      GlobalDurationTimer.stop();
-    };
-  }
-
-  static aggregateRequestBodyToSpan(
-    body,
-    requestData,
-    currentSpan,
-    maxSize = getEventEntitySize(true)
-  ) {
-    let serviceData: ServiceData = {};
-    if (body && !requestData.truncated) {
-      requestData.body += body;
-      serviceData = getServiceData(requestData, null);
-      const truncated = maxSize < requestData.body.length;
-      if (truncated) requestData.body = requestData.body.substr(0, maxSize);
-      requestData.truncated = truncated;
-    }
-    if (currentSpan) {
-      currentSpan.info.httpInfo = getHttpInfo(requestData, {});
-      Object.assign(currentSpan.info, {
-        ...serviceData.awsServiceData,
-      });
-    }
-  }
+  // static httpRequestEndWrapper(requestData, currentSpan) {
+  //   return function (args) {
+  //     GlobalDurationTimer.start();
+  //     if (isEmptyString(requestData.body)) {
+  //       const body = extractBodyFromWriteOrEndFunc(args);
+  //       Http.aggregateRequestBodyToSpan(body, requestData, currentSpan, getEventEntitySize(true));
+  //     }
+  //     GlobalDurationTimer.stop();
+  //   };
+  // }
 
   @GlobalDurationTimer.timedSync()
-  static httpRequestArguments(args) {
+  static httpRequestArguments(args: any[]): { url?: string; options?: any; callback?: Function } {
     if (args.length === 0) {
       throw new Error('http/s.request(...) was called without any arguments.');
     }
@@ -153,113 +88,36 @@ export class Http {
     }
   }
 
-  static isBlacklisted(host) {
-    return host === getEdgeHost() || hostBlaclist.has(host);
-  }
-
-  static scrubQueryParams(search: string): string {
-    return (
-      safeExecute(() => {
-        const query = parseQuery(search.substring(1));
-        const scrubbedQuery = shallowMask('queryParams', query);
-        return '?' + new URLSearchParams(scrubbedQuery);
-      })() || ''
-    );
-  }
-
-  @GlobalDurationTimer.timedSync()
-  static parseHttpRequestOptions(options: ParseHttpRequestOptions = {}, url) {
-    const host = Http.getHostFromOptionsOrUrl(options, url);
-    const agent = options.agent || options._defaultAgent;
-
-    let path = null;
-    let port = null;
-    let search = null;
-    let protocol = null;
-
-    let { headers, method = 'GET' } = options;
-    const sendTime = new Date().getTime();
-
-    if (url) {
-      const myUrl = new URL(url);
-      ({ pathname: path, port, protocol, search } = myUrl);
-    } else {
-      path = options.path || '/';
-      port = options.port || options.defaultPort || (agent && agent.defaultPort) || 80;
-      protocol = options.protocol || (port === 443 && 'https:') || 'http:';
-    }
-
-    if (headers && !headers.host) {
-      headers = addHeaders(headers, { host });
-    }
-
-    if (!!search) {
-      search = Http.scrubQueryParams(search);
-    } else {
-      search = '';
-    }
-
-    const uri = `${host}${path}${search}`;
-
-    return {
-      truncated: false,
-      path,
-      port,
-      uri,
-      host,
-      body: '', // XXX Filled by the httpRequestEndWrapper or httpRequestEmitBeforeHookWrapper ( / Write)
-      method,
-      headers: lowerCaseObjectKeys(headers),
-      protocol,
-      sendTime,
-    };
-  }
-
   @GlobalDurationTimer.timedSync()
   static httpBeforeRequestWrapper(args, extenderContext) {
     extenderContext.isTracedDisabled = true;
-    // @ts-ignore
-    const { awsRequestId } = TracerGlobals.getHandlerInputs().context;
-    const transactionId = getCurrentTransactionId();
+    const { url, options = {} } = Http.httpRequestArguments(args);
+    const {
+      addedHeaders = undefined,
+      httpSpan = undefined,
+      requestData = undefined,
+      requestRandomId = undefined,
+      awsRequestId = undefined,
+      transactionId = undefined,
+    } = BaseHttp.onRequestCreated({
+      options,
+      url,
+    });
+
+    if (!httpSpan) {
+      return;
+    }
+
     extenderContext.awsRequestId = awsRequestId;
     extenderContext.transactionId = transactionId;
-    extenderContext.isTracedDisabled = false;
+    extenderContext.requestRandomId = requestRandomId;
+    extenderContext.requestData = requestData;
+    extenderContext.currentSpan = httpSpan;
 
-    const { url, options = {} } = Http.httpRequestArguments(args);
-    const headers = options?.headers || {};
-    const host = Http.getHostFromOptionsOrUrl(options, url);
-    extenderContext.isTracedDisabled =
-      Http.isBlacklisted(host) || !isValidAlias() || GlobalDurationTimer.isTimePassed();
-
-    if (!extenderContext.isTracedDisabled) {
-      logger.debug('Starting hook', { host, url, headers });
-
-      const isRequestToAwsService = isAwsService(host);
-      if (isRequestToAwsService && !isKeepHeadersOn()) {
-        const { awsXAmznTraceId } = getAWSEnvironment();
-        const traceId = getPatchedTraceId(awsXAmznTraceId);
-        headers && (headers['X-Amzn-Trace-Id'] = traceId);
-      }
-
-      if (shouldPropagateW3C()) {
-        safeExecute(() => {
-          options.headers = addW3CTracePropagator(headers);
-          Http.addOptionsToHttpRequestArguments(args, options);
-        })();
-      }
-
-      const requestData = Http.parseHttpRequestOptions(options, url);
-      const requestRandomId = getRandomId();
-
-      extenderContext.requestRandomId = requestRandomId;
-      extenderContext.requestData = requestData;
-
-      if (isTimeoutTimerEnabled()) {
-        const httpSpan = getHttpSpan(transactionId, awsRequestId, requestRandomId, requestData);
-        SpansContainer.addSpan(httpSpan);
-        extenderContext.currentSpan = httpSpan;
-      }
+    if (addedHeaders) {
+      Http.addOptionsToHttpRequestArguments(args, options);
     }
+    extenderContext.isTracedDisabled = false;
   }
 
   @GlobalDurationTimer.timedSync()
@@ -273,38 +131,47 @@ export class Http {
       transactionId,
       currentSpan,
     } = extenderContext;
-    if (!isTracedDisabled) {
-      const endWrapper = Http.httpRequestEndWrapper(requestData, currentSpan);
-
-      const emitWrapper = Http.httpRequestEmitBeforeHookWrapper(
-        transactionId,
-        awsRequestId,
-        requestData,
-        requestRandomId,
-        currentSpan
-      );
-
-      const writeWrapper = Http.httpRequestWriteBeforeHookWrapper(requestData, currentSpan);
-
-      extender.hook(clientRequest, 'end', { beforeHook: endWrapper });
-      extender.hook(clientRequest, 'emit', { beforeHook: emitWrapper });
-      extender.hook(clientRequest, 'write', { beforeHook: writeWrapper });
+    if (isTracedDisabled) {
+      return;
     }
-  }
 
-  static httpRequestWriteBeforeHookWrapper(requestData, currentSpan) {
-    return function (args) {
-      GlobalDurationTimer.start();
-      if (isEmptyString(requestData.body)) {
-        const body = extractBodyFromWriteOrEndFunc(args);
-        Http.aggregateRequestBodyToSpan(body, requestData, currentSpan, getEventEntitySize(true));
-      }
-      GlobalDurationTimer.stop();
-    };
+    const endWrapper = BaseHttp.createRequestDataWriteHandler({ requestData, currentSpan });
+
+    const emitWrapper = Http.httpRequestEmitBeforeHookWrapper(
+      transactionId,
+      awsRequestId,
+      requestData,
+      requestRandomId,
+      currentSpan
+    );
+
+    const writeWrapper = BaseHttp.createRequestDataWriteHandler({ requestData, currentSpan });
+
+    // Finishes sending the request. If any parts of the body are unsent, it will flush them to the stream.
+    // If the request is chunked, this will send the terminating '0\r\n\r\n'.
+    // Input is:
+    // - data: <string> | <Buffer> | <Uint8Array>
+    // - encoding: <string>
+    // - callback: <Function>
+    // Returns: <this>
+    extender.hook(clientRequest, 'end', { beforeHook: endWrapper });
+
+    extender.hook(clientRequest, 'emit', { beforeHook: emitWrapper });
+
+    // Sends a chunk of the body. This method can be called multiple times. If no Content-Length is set,
+    // data will automatically be encoded in HTTP Chunked transfer encoding, so that server knows when the data ends.
+    // The Transfer-Encoding: chunked header is added.
+    // Calling request.end() is necessary to finish sending the request.
+    // Input is:
+    // - chunk: <string> | <Buffer> | <Uint8Array>
+    // - encoding: <string>
+    // - callback: <Function>
+    // Returns: <boolean>
+    extender.hook(clientRequest, 'write', { beforeHook: writeWrapper });
   }
 
   @GlobalDurationTimer.timedSync()
-  static addStepFunctionEvent(messageId) {
+  static addStepFunctionEvent(messageId: string) {
     // @ts-ignore
     const awsRequestId = TracerGlobals.getHandlerInputs().context.awsRequestId;
     const transactionId = getCurrentTransactionId();
@@ -334,68 +201,20 @@ export class Http {
     Http.wrapHttpLib(https);
   }
 
-  static createEmitResponseOnEmitBeforeHookHandler(
-    transactionId,
-    awsRequestId,
-    requestData,
-    requestRandomId,
-    response
+  static createEmitResponseHandler(
+    transactionId: string,
+    awsRequestId: string,
+    requestData: { body: string },
+    requestRandomId: string
   ) {
-    let body = '';
-    let maxPayloadSize = getEventEntitySize(true);
-    return function (args) {
-      GlobalDurationTimer.start();
-      const receivedTime = new Date().getTime();
-      let truncated = false;
-      const { headers, statusCode } = response;
-      // add to body only if we didnt pass the max size
-      if (args[0] === 'data' && body.length < maxPayloadSize) {
-        let chunk = httpDataToString(args[1]);
-        const allowedLengthToAdd = maxPayloadSize - body.length;
-        //if we reached or close to limit get only substring of the part to reach the limit
-        if (chunk.length > allowedLengthToAdd) {
-          truncated = true;
-          chunk = chunk.substr(0, allowedLengthToAdd);
-        }
-        body += chunk;
-      }
-      if (args[0] === 'end') {
-        let maxSizeNoErrors = getEventEntitySize();
-        const responseData = {
-          statusCode,
-          receivedTime,
-          body:
-            statusCode < 400 && body.length > maxSizeNoErrors // if there are no errors cut the size to max allowed with no errors
-              ? body.substr(0, maxSizeNoErrors)
-              : body,
-          headers: lowerCaseObjectKeys(headers),
-        };
-        const httpSpan = getHttpSpan(
-          transactionId,
-          awsRequestId,
-          requestRandomId,
-          requestData,
-          Object.assign({ truncated }, responseData)
-        );
-        if (httpSpan.id !== requestRandomId) {
-          // In Http case, one of our parser decide to change the spanId for async connection
-          SpansContainer.changeSpanId(requestRandomId, httpSpan.id);
-        }
-        SpansContainer.addSpan(httpSpan);
-      }
-      GlobalDurationTimer.stop();
-    };
-  }
-
-  static createEmitResponseHandler(transactionId, awsRequestId, requestData, requestRandomId) {
-    return (response) => {
-      const onHandler = Http.createEmitResponseOnEmitBeforeHookHandler(
+    return (response: { headers: {}; statusCode: number }) => {
+      const onHandler = BaseHttp.createResponseDataWriterHandler({
         transactionId,
         awsRequestId,
         requestData,
         requestRandomId,
-        response
-      );
+        response,
+      });
       extender.hook(response, 'emit', {
         beforeHook: onHandler,
       });
@@ -403,11 +222,11 @@ export class Http {
   }
 
   static httpRequestEmitBeforeHookWrapper(
-    transactionId,
-    awsRequestId,
-    requestData,
-    requestRandomId,
-    currentSpan
+    transactionId: string,
+    awsRequestId: string,
+    requestData: { body: string },
+    requestRandomId: string,
+    currentSpan: BasicChildSpan
   ) {
     const emitResponseHandler = Http.createEmitResponseHandler(
       transactionId,
@@ -416,16 +235,17 @@ export class Http {
       requestRandomId
     );
     const oneTimerEmitResponseHandler = runOneTimeWrapper(emitResponseHandler, {});
-    return function (args) {
+    const socketWriteRequestHandler = BaseHttp.createRequestSocketDataWriteHandler({
+      requestData,
+      currentSpan,
+    });
+    return function (args: any[]) {
       GlobalDurationTimer.start();
       if (args[0] === 'response') {
         oneTimerEmitResponseHandler(args[1]);
       }
       if (args[0] === 'socket') {
-        if (isEmptyString(requestData.body)) {
-          const body = extractBodyFromEmitSocketEvent(args[1]);
-          Http.aggregateRequestBodyToSpan(body, requestData, currentSpan, getEventEntitySize(true));
-        }
+        socketWriteRequestHandler(args[1]);
       }
       GlobalDurationTimer.stop();
     };

--- a/src/hooks/http.ts
+++ b/src/hooks/http.ts
@@ -16,17 +16,6 @@ export type Agent = {
 };
 
 export class Http {
-  // static httpRequestEndWrapper(requestData, currentSpan) {
-  //   return function (args) {
-  //     GlobalDurationTimer.start();
-  //     if (isEmptyString(requestData.body)) {
-  //       const body = extractBodyFromWriteOrEndFunc(args);
-  //       Http.aggregateRequestBodyToSpan(body, requestData, currentSpan, getEventEntitySize(true));
-  //     }
-  //     GlobalDurationTimer.stop();
-  //   };
-  // }
-
   @GlobalDurationTimer.timedSync()
   static httpRequestArguments(args: any[]): { url?: string; options?: any; callback?: Function } {
     if (args.length === 0) {

--- a/src/hooks/http.ts
+++ b/src/hooks/http.ts
@@ -101,6 +101,7 @@ export class Http {
     }
     const {
       addedHeaders,
+      headers,
       requestRandomId,
       awsRequestId,
       transactionId,
@@ -119,6 +120,7 @@ export class Http {
     }
 
     if (addedHeaders) {
+      options.headers = headers;
       Http.addOptionsToHttpRequestArguments(args, options);
     }
     extenderContext.isTracedDisabled = false;

--- a/src/hooks/http.ts
+++ b/src/hooks/http.ts
@@ -92,27 +92,31 @@ export class Http {
   static httpBeforeRequestWrapper(args, extenderContext) {
     extenderContext.isTracedDisabled = true;
     const { url, options = {} } = Http.httpRequestArguments(args);
-    const {
-      addedHeaders = undefined,
-      httpSpan = undefined,
-      requestData = undefined,
-      requestRandomId = undefined,
-      awsRequestId = undefined,
-      transactionId = undefined,
-    } = BaseHttp.onRequestCreated({
+    const requestTracingData = BaseHttp.onRequestCreated({
       options,
       url,
     });
-
-    if (!httpSpan) {
+    if (!requestTracingData) {
       return;
     }
+    const {
+      addedHeaders,
+      requestRandomId,
+      awsRequestId,
+      transactionId,
+      httpSpan = undefined,
+      requestData = undefined,
+    } = requestTracingData;
 
     extenderContext.awsRequestId = awsRequestId;
     extenderContext.transactionId = transactionId;
     extenderContext.requestRandomId = requestRandomId;
-    extenderContext.requestData = requestData;
-    extenderContext.currentSpan = httpSpan;
+    if (requestData) {
+      extenderContext.requestData = requestData;
+    }
+    if (httpSpan) {
+      extenderContext.currentSpan = httpSpan;
+    }
 
     if (addedHeaders) {
       Http.addOptionsToHttpRequestArguments(args, options);

--- a/src/hooks/httpUtils.js
+++ b/src/hooks/httpUtils.js
@@ -34,6 +34,14 @@ export const httpDataToString = (data) => {
 };
 
 export const extractBodyFromWriteOrEndFunc = (writeEventArgs) => {
+  /**
+   * Extract the body from the given arguments list, where the arguments are:
+   * 0 - The request body, as a string, Buffer or any other type that can be converted to a string using toString().
+   * 1 - The encoding of the request body (example values: 'ascii', 'utf8', 'utf16le', 'ucs2', 'base64', 'binary', 'hex').
+   *     If the value is missing / unknown the default value is 'utf8'.
+   *
+   * The input is a list of arguments for legacy reasons
+   */
   return safeExecute(() => {
     if (isValidHttpRequestBody(writeEventArgs[0])) {
       const encoding = isEncodingType(writeEventArgs[1]) ? writeEventArgs[1] : 'utf8';

--- a/src/spans/awsSpan.ts
+++ b/src/spans/awsSpan.ts
@@ -40,7 +40,7 @@ import {
 import { payloadStringify, shallowMask, truncate } from '../utils/payloadStringify';
 import { Utf8Utils } from '../utils/utf8Utils';
 import { getW3CMessageId } from '../utils/w3cUtils';
-import { int } from 'aws-sdk/clients/datapipeline';
+import { RequestData } from '../hooks/baseHttp';
 
 export const HTTP_SPAN = 'http';
 export const FUNCTION_SPAN = 'function';
@@ -315,6 +315,7 @@ export type ServiceData = {
   messageId?: string;
   [key: string]: any;
 };
+
 export const getServiceData = (requestData, responseData): ServiceData => {
   const { host } = requestData;
 
@@ -381,7 +382,7 @@ export const getHttpSpan = (
   transactionId,
   awsRequestId,
   randomRequestId,
-  requestData,
+  requestData: RequestData,
   responseData = { truncated: false, body: undefined, headers: undefined }
 ) => {
   let serviceData = {};

--- a/src/spans/awsSpan.ts
+++ b/src/spans/awsSpan.ts
@@ -417,10 +417,7 @@ export const getHttpSpan = (
     HTTP_SPAN
   );
 
-  const info = Object.assign({}, basicHttpSpan.info, {
-    httpInfo,
-    ...awsServiceData,
-  });
+  const info = Object.assign({}, basicHttpSpan.info, { httpInfo }, awsServiceData);
 
   // add messageId based on W3cContextPropagation in case of messageId not present
   if (!info.messageId) {

--- a/src/spans/awsSpan.ts
+++ b/src/spans/awsSpan.ts
@@ -348,7 +348,7 @@ export const decodeHttpBody = (httpBody: any, hasError: boolean): any | string =
   return httpBody;
 };
 
-export const getHttpInfo = (requestData, responseData): HttpInfo => {
+export const getHttpInfo = (requestData: RequestData, responseData): HttpInfo => {
   const { host } = requestData;
   const request = Object.assign({}, requestData);
   const response = Object.assign({}, responseData);
@@ -417,7 +417,7 @@ export const getHttpSpan = (
     HTTP_SPAN
   );
 
-  let info = Object.assign({}, basicHttpSpan.info, {
+  const info = Object.assign({}, basicHttpSpan.info, {
     httpInfo,
     ...awsServiceData,
   });

--- a/src/types/spans/basicSpan.ts
+++ b/src/types/spans/basicSpan.ts
@@ -1,3 +1,5 @@
+import { HttpInfo } from './httpSpan';
+
 export type Vendor = 'AWS';
 
 export interface SpanInfo {
@@ -12,7 +14,7 @@ export interface SpanInfo {
 
 export interface BasicSpan {
   id: string;
-  info: SpanInfo;
+  info: SpanInfo | { httpInfo: HttpInfo };
   vendor: Vendor;
   transactionId: string;
   account: string;

--- a/src/utils/requireUtils.js
+++ b/src/utils/requireUtils.js
@@ -1,6 +1,7 @@
 import * as logger from '../logger';
 
 export const safeRequire = (libId) => {
+  // Dummy comment, will be removed
   try {
     const customReq =
       // eslint-disable-next-line no-undef,camelcase

--- a/src/utils/requireUtils.js
+++ b/src/utils/requireUtils.js
@@ -1,7 +1,6 @@
 import * as logger from '../logger';
 
 export const safeRequire = (libId) => {
-  // Dummy comment, will be removed
   try {
     const customReq =
       // eslint-disable-next-line no-undef,camelcase

--- a/src/utils/w3cUtils.test.ts
+++ b/src/utils/w3cUtils.test.ts
@@ -58,6 +58,13 @@ describe('Utf8Utils', () => {
     expect(headers[TRACESTATE_HEADER_NAME]).toEqual(`lumigo=${parts[2]}`);
   });
 
+  test('addW3CTracePropagator -> no new headers added', () => {
+    const headers = { 'x-amz-content-sha256': '123' };
+    const returnedHeaders = addW3CTracePropagator(headers);
+    expect(headers).toEqual({ 'x-amz-content-sha256': '123' });
+    expect(returnedHeaders).toEqual({ 'x-amz-content-sha256': '123' });
+  });
+
   test('getW3CMessageId -> happy flow', () => {
     const headers = {
       [TRACEPARENT_HEADER_NAME]: '00-11111111111111111111111100000000-aaaaaaaaaaaaaaaa-01',

--- a/src/utils/w3cUtils.test.ts
+++ b/src/utils/w3cUtils.test.ts
@@ -58,11 +58,16 @@ describe('Utf8Utils', () => {
     expect(headers[TRACESTATE_HEADER_NAME]).toEqual(`lumigo=${parts[2]}`);
   });
 
-  test('addW3CTracePropagator -> no new headers added', () => {
-    const headers = { 'x-amz-content-sha256': '123' };
-    const returnedHeaders = addW3CTracePropagator(headers);
-    expect(headers).toEqual({ 'x-amz-content-sha256': '123' });
-    expect(returnedHeaders).toEqual({ 'x-amz-content-sha256': '123' });
+  [
+    { 'x-amz-content-sha256': '123' },
+    { 'x-amz-content-sha256': '123', 'Content-Type': 'application/json' },
+  ].map((headers) => {
+    test(`aaddW3CTracePropagator -> no new headers added`, () => {
+      const originalHeaders = { ...headers };
+      const returnedHeaders = addW3CTracePropagator(headers);
+      expect(headers).toEqual(originalHeaders);
+      expect(returnedHeaders).toEqual(originalHeaders);
+    });
   });
 
   test('getW3CMessageId -> happy flow', () => {

--- a/src/utils/w3cUtils.test.ts
+++ b/src/utils/w3cUtils.test.ts
@@ -62,7 +62,7 @@ describe('Utf8Utils', () => {
     { 'x-amz-content-sha256': '123' },
     { 'x-amz-content-sha256': '123', 'Content-Type': 'application/json' },
   ].map((headers) => {
-    test(`aaddW3CTracePropagator -> no new headers added`, () => {
+    test(`aaddW3CTracePropagator -> no new headers added when sha256 header present`, () => {
       const originalHeaders = { ...headers };
       const returnedHeaders = addW3CTracePropagator(headers);
       expect(headers).toEqual(originalHeaders);

--- a/src/utils/w3cUtils.ts
+++ b/src/utils/w3cUtils.ts
@@ -17,15 +17,27 @@ export const shouldSkipTracePropagation = (headers: Record<string, string>): boo
   return Object.keys(headers).some((key) => SKIP_INJECT_HEADERS.includes(key.toLowerCase()));
 };
 
-export const addW3CTracePropagator = (headers: Record<string, string>): Record<string, string> => {
+export const getW3CTracerPropagatorAdditionalHeaders = (
+  headers: Record<string, string>
+): Record<string, string> => {
   if (shouldSkipTracePropagation(headers)) {
     logger.debug('Skipping trace propagation');
-    return headers;
+    return {};
   }
   const messageId = generateMessageId();
-  headers[TRACEPARENT_HEADER_NAME] = getTraceId(headers, getCurrentTransactionId(), messageId);
-  headers[TRACESTATE_HEADER_NAME] = getTraceState(headers, messageId);
-  return headers;
+  return {
+    [TRACEPARENT_HEADER_NAME]: getTraceId(headers, getCurrentTransactionId(), messageId),
+    [TRACESTATE_HEADER_NAME]: getTraceState(headers, messageId),
+  };
+};
+
+export const addW3CTracePropagator = (headers: Record<string, string>): Record<string, string> => {
+  const additionalHeaders = getW3CTracerPropagatorAdditionalHeaders(headers);
+  if (!additionalHeaders) {
+    return headers;
+  }
+
+  return Object.assign(headers, additionalHeaders);
 };
 
 const parseW3CHeader = (headers: Record<string, string>) => {
@@ -49,6 +61,7 @@ const getTraceId = (
 ): string => {
   // Create the TraceId: either by continuing the transaction that we already see from the headers,
   //   or by creating a new transaction. The spanId is this span (the next component's parent).
+  // eslint-disable-next-line prefer-const
   let { version, traceId, spanId, traceFlags } = parseW3CHeader(headers);
   if (
     !version ||

--- a/src/utils/w3cUtils.ts
+++ b/src/utils/w3cUtils.ts
@@ -33,10 +33,6 @@ export const getW3CTracerPropagatorAdditionalHeaders = (
 
 export const addW3CTracePropagator = (headers: Record<string, string>): Record<string, string> => {
   const additionalHeaders = getW3CTracerPropagatorAdditionalHeaders(headers);
-  if (!additionalHeaders) {
-    return headers;
-  }
-
   return Object.assign(headers, additionalHeaders);
 };
 


### PR DESCRIPTION
This is the first stage of adding native node fetch instrumentation.

This PR splits the existing http library instrumentation to the core logic of tracing a generic http request (the `BaseHttp` class) and the instrumentation connecting that logic to the `http` / `https` libraries (the `Http` class).

The next stage will be in a separate PR that will use the `BaseHttp` class to integrate to a new http library called `undici` (This is the library that native node fetch uses behind the scenes)