### PR TITLE
fix: descrease the bulk size to ensure it is small enough

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,6 @@ workflows:
         context: common
         requires:
           - lumigo-orb/integration-test-parallel
-          - lumigo-orb/e2e-test
 
     - lumigo-orb/workflow-completed-successfully:
         context: common

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,25 +34,16 @@ workflows:
         requires:
           - lumigo-orb/is_environment_available
 
-    - lumigo-orb/pre_build_artifacts:
+    - lumigo-orb/prep-it-resources:
         context: common
-        save_project_folder: true
         requires:
           - lumigo-orb/is_environment_available
 
-    - lumigo-orb/integration-test-prep:
-        context: common
-        pre_builds_available: true
-        run_test_cleanup: false
-        requires:
-          - lumigo-orb/pre_build_artifacts
-
-    - lumigo-orb/integration-test-cleanup:
-        name: pre-test-cleanup
+    - lumigo-orb/prep-k8s-and-operator:
         context: common
         requires:
-          - lumigo-orb/pre_build_artifacts
-
+          - lumigo-orb/is_environment_available
+    
     - lumigo-orb/integration-test-parallel:
         context: common
         tests_spec: testNode
@@ -60,14 +51,15 @@ workflows:
         tests_max_parallel: 20
         requires:
           - lumigo-orb/be-deploy
-          - lumigo-orb/integration-test-prep
-          - pre-test-cleanup
+          - lumigo-orb/prep-it-resources
+          - lumigo-orb/prep-k8s-and-operator
 
     - lumigo-orb/integration-test-cleanup:
         name: post-test-cleanup
         context: common
         requires:
           - lumigo-orb/integration-test-parallel
+          - lumigo-orb/e2e-test
 
     - lumigo-orb/workflow-completed-successfully:
         context: common

--- a/src/reporter.test.ts
+++ b/src/reporter.test.ts
@@ -1246,4 +1246,20 @@ describe('reporter', () => {
 
     expect(sentSpans).toEqual([spans]);
   });
+
+  test('splitAndZipSpans -> verify it splits to bulks successfully', () => {
+    const spans = new Array(reporter.NUMBER_OF_SPANS_IN_REPORT_OPTIMIZATION * 2).fill({});
+
+    const splitSpans = reporter.splitAndZipSpans(spans);
+    expect(splitSpans.length).toEqual(
+      (reporter.NUMBER_OF_SPANS_IN_REPORT_OPTIMIZATION * 2) / reporter.MAX_SPANS_BULK_SIZE
+    );
+
+    // test unzipping
+    const unzippedSpans = splitSpans.flatMap((span) => {
+      const unzipped = unzipSync(Buffer.from(span, 'base64')).toString();
+      return JSON.parse(unzipped);
+    });
+    expect(unzippedSpans).toEqual(spans);
+  });
 });

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -19,7 +19,7 @@ import untruncateJson from './tools/untrancateJson';
 import { gzipSync } from 'zlib';
 
 export const NUMBER_OF_SPANS_IN_REPORT_OPTIMIZATION = 200;
-const MAX_SPANS_BULK_SIZE = 200;
+export const MAX_SPANS_BULK_SIZE = 200;
 
 export const sendSingleSpan = async (span) => sendSpans([span]);
 
@@ -156,7 +156,7 @@ export function getPrioritizedSpans(spans: any[], maxSendBytes: number): any[] {
   return Object.values(spansToSend);
 }
 
-function splitAndZipSpans(spans: any[]): string[] {
+export function splitAndZipSpans(spans: any[]): string[] {
   logger.debug(`Splitting the spans to bulks of ${MAX_SPANS_BULK_SIZE} spans`);
   // Split the spans to bulks and zip each one
   const spansBulks: string[] = [];

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -201,6 +201,8 @@ export const forgeAndScrubRequestBody = (
       if (areAllSpansSmallEnough) {
         logger.debug(`Created ${zippedSpansBulks.length} bulks of zipped spans`);
         return zippedSpansBulks;
+      } else {
+        logger.info(`Some of the zipped bulks are still too big, continuing to trim the spans`);
       }
     }
     logger.debug(

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -201,8 +201,6 @@ export const forgeAndScrubRequestBody = (
       if (areAllSpansSmallEnough) {
         logger.debug(`Created ${zippedSpansBulks.length} bulks of zipped spans`);
         return zippedSpansBulks;
-      } else {
-        logger.info(`Some of the zipped bulks are still too big, continuing to trim the spans`);
       }
     }
     logger.debug(

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -19,7 +19,7 @@ import untruncateJson from './tools/untrancateJson';
 import { gzipSync } from 'zlib';
 
 export const NUMBER_OF_SPANS_IN_REPORT_OPTIMIZATION = 200;
-const MAX_SPANS_BULK_SIZE = 500;
+const MAX_SPANS_BULK_SIZE = 200;
 
 export const sendSingleSpan = async (span) => sendSpans([span]);
 


### PR DESCRIPTION
Bulks of spans of size 500 can be too big to send - decreasing to 200.