### PR TITLE
fix: export keyword breaking auto-instrument-handler at Runtime

### DIFF
--- a/auto-instrument-handler/index.js
+++ b/auto-instrument-handler/index.js
@@ -21,7 +21,7 @@ const getHandlerAsync = async () => {
   );
 };
 
-export const removeLumigoFromError = (stacktrace) => {
+const removeLumigoFromError = (stacktrace) => {
   const stackArr = stacktrace.split('\n');
 
   const patterns = ['/dist/lumigo.js:', 'auto-instrument'];


### PR DESCRIPTION
Fixes #502

Because the file `auto-instrument-handler/index.js` is a "CommonJS" File, the "export" Keyword is not allowed in there.