### PR TITLE
fix: revert remove lumigo from stack when error is raised from a promise after the lambdas execution finished

### DIFF
--- a/auto-instrument-handler/index.js
+++ b/auto-instrument-handler/index.js
@@ -21,22 +21,19 @@ const getHandlerAsync = async () => {
   );
 };
 
-export const removeLumigoFromError = (stacktrace) => {
-  const stackArr = stacktrace.split('\n');
-
-  const patterns = ['/dist/lumigo.js:', 'auto-instrument'];
-  const cleanedStack = stackArr.filter(v => !patterns.some(p => v.includes(p)));
-
-  return cleanedStack.join('\n');
-}
-
 const removeLumigoFromStacktrace = err => {
   // Note: this function was copied from utils.js. Keep them both up to date.
   try {
     if (!err || !err.stack) {
       return err;
     }
-    err.stack = removeLumigoFromError(err.stack);
+    const { stack } = err;
+    const stackArr = stack.split('\n');
+
+    const patterns = ['/dist/lumigo.js:', 'auto-instrument'];
+    const cleanedStack = stackArr.filter(v => !patterns.some(p => v.includes(p)));
+
+    err.stack = cleanedStack.join('\n');
 
     return err;
   } catch (e) {

--- a/auto-instrument-handler/index.test.js
+++ b/auto-instrument-handler/index.test.js
@@ -42,36 +42,4 @@ describe('tracer', () => {
     expect(index.handler({}, {})).resolves.toEqual({ hello: 'world' });
   });
 
-  test('removeLumigoFromStacktrace - unhandled promise exception', () => {
-    const err = {
-        stack:
-            'Error: Error: I am an error\n    ' +
-            'at /opt/nodejs/node_modules/@lumigo/tracer/dist/tracer/tracer.js:269:31\n    ' +
-            'at step (/opt/nodejs/node_modules/@lumigo/tracer/dist/tracer/tracer.js:33:23)\n    ' +
-            'at Object.next (/opt/nodejs/node_modules/@lumigo/tracer/dist/tracer/tracer.js:14:53)\n    ' +
-            'at /opt/nodejs/node_modules/@lumigo/tracer/dist/tracer/tracer.js:8:71\n    ' +
-            'at new Promise (<anonymous>)\n    ' +
-            'at __awaiter (/opt/nodejs/node_modules/@lumigo/tracer/dist/tracer/tracer.js:4:12)\n    ' +
-            'at events.unhandledRejection (/opt/nodejs/node_modules/@lumigo/tracer/dist/tracer/tracer.js:264:73)\n    ' +
-            'at process.emit (node:events:519:28)\n    ' +
-            'at emitUnhandledRejection (node:internal/process/promises:250:13)\n    ' +
-            'at throwUnhandledRejectionsMode (node:internal/process/promises:385:19)',
-    };
-
-    const data = 'abcd';
-    const type = '1234';
-    const handlerReturnValue = { err, data, type };
-
-    const expectedErr = {
-        stack:
-            'Error: Error: I am an error\n    ' +
-            'at new Promise (<anonymous>)\n    ' +
-            'at process.emit (node:events:519:28)\n    ' +
-            'at emitUnhandledRejection (node:internal/process/promises:250:13)\n    ' +
-            'at throwUnhandledRejectionsMode (node:internal/process/promises:385:19)',
-    };
-    const expectedHandlerReturnValue = { err: expectedErr, data, type };
-
-    expect(index.removeLumigoFromStacktrace(handlerReturnValue)).toEqual(expectedHandlerReturnValue);
-  });
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,7 +9,7 @@ module.exports = () => {
   ];
   let coverageThreshold = {
     global: {
-      lines: 99.6,
+      lines: 99.7,
     },
   };
 
@@ -22,7 +22,7 @@ module.exports = () => {
   if (NODE_MAJOR_VERSION > 14) {
     // Some of our unit tests don't work on Node.js grater than 14,
     // so the coverage is lower when running with these versions
-    coverageThreshold.global.lines = 98.3;
+    coverageThreshold.global.lines = 98.4;
   }
 
   return {

--- a/src/tracer/tracer.ts
+++ b/src/tracer/tracer.ts
@@ -33,7 +33,6 @@ import {
   safeExecute,
   STEP_FUNCTION_UID_KEY,
   SWITCH_OFF_FLAG,
-  removeLumigoFromError,
 } from '../utils';
 import { runOneTimeWrapper } from '../utils/functionUtils';
 import { TraceOptions } from './trace-options.type';
@@ -225,11 +224,6 @@ export const hookUnhandledRejection = async (functionSpan) => {
   events.unhandledRejection = async (reason, promise) => {
     const err = Error(reason);
     err.name = 'Runtime.UnhandledPromiseRejection';
-    try {
-      err.stack = removeLumigoFromError(err.stack);
-    } catch (errFromRemoveLumigo) {
-      logger.warn('Failed to remove Lumigo from stacktrace', errFromRemoveLumigo);
-    }
     await endTrace(functionSpan, {
       err: err,
       type: ASYNC_HANDLER_REJECTED,

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -32,8 +32,6 @@ import {
   getMaxSizeForStoredSpansInMemory,
   LUMIGO_STORED_SPANS_MAX_SIZE_BYTES_ENV_VAR,
   LUMIGO_SUPPORT_LARGE_INVOCATIONS,
-  removeLumigoFromError,
-  removeLumigoFromStacktrace,
 } from './utils';
 
 describe('utils', () => {
@@ -772,40 +770,6 @@ describe('utils', () => {
     );
   });
 
-  test('removeLumigoFromStacktrace - unhandled promise exception', () => {
-    const err = {
-      stack:
-        'Error: Error: I am an error\n    ' +
-        'at /opt/nodejs/node_modules/@lumigo/tracer/dist/tracer/tracer.js:269:31\n    ' +
-        'at step (/opt/nodejs/node_modules/@lumigo/tracer/dist/tracer/tracer.js:33:23)\n    ' +
-        'at Object.next (/opt/nodejs/node_modules/@lumigo/tracer/dist/tracer/tracer.js:14:53)\n    ' +
-        'at /opt/nodejs/node_modules/@lumigo/tracer/dist/tracer/tracer.js:8:71\n    ' +
-        'at new Promise (<anonymous>)\n    ' +
-        'at __awaiter (/opt/nodejs/node_modules/@lumigo/tracer/dist/tracer/tracer.js:4:12)\n    ' +
-        'at events.unhandledRejection (/opt/nodejs/node_modules/@lumigo/tracer/dist/tracer/tracer.js:264:73)\n    ' +
-        'at process.emit (node:events:519:28)\n    ' +
-        'at emitUnhandledRejection (node:internal/process/promises:250:13)\n    ' +
-        'at throwUnhandledRejectionsMode (node:internal/process/promises:385:19)',
-    };
-
-    const data = 'abcd';
-    const type = '1234';
-    const handlerReturnValue = { err, data, type };
-
-    const expectedErr = {
-      stack:
-        'Error: Error: I am an error\n    ' +
-        'at new Promise (<anonymous>)\n    ' +
-        'at process.emit (node:events:519:28)\n    ' +
-        'at emitUnhandledRejection (node:internal/process/promises:250:13)\n    ' +
-        'at throwUnhandledRejectionsMode (node:internal/process/promises:385:19)',
-    };
-    const expectedHandlerReturnValue = { err: expectedErr, data, type };
-
-    expect(utils.removeLumigoFromStacktrace(handlerReturnValue)).toEqual(
-      expectedHandlerReturnValue
-    );
-  });
   test('removeLumigoFromStacktrace no exception', () => {
     utils.removeLumigoFromStacktrace(null);
     // No exception.
@@ -1174,31 +1138,5 @@ describe('utils', () => {
       defaultReturn: 0,
     })({ a: 2, b: 3 });
     expect(result).toEqual(5);
-  });
-
-  test('removelumigoFromError', () => {
-    const err = Error('Error: I am an error');
-    err.stack =
-      'Error: Error: I am an error\n    ' +
-      'at /opt/nodejs/node_modules/@lumigo/tracer/dist/tracer/tracer.js:269:31\n    ' +
-      'at step (/opt/nodejs/node_modules/@lumigo/tracer/dist/tracer/tracer.js:33:23)\n    ' +
-      'at Object.next (/opt/nodejs/node_modules/@lumigo/tracer/dist/tracer/tracer.js:14:53)\n    ' +
-      'at /opt/nodejs/node_modules/@lumigo/tracer/dist/tracer/tracer.js:8:71\n    ' +
-      'at new Promise (<anonymous>)\n    ' +
-      'at __awaiter (/opt/nodejs/node_modules/@lumigo/tracer/dist/tracer/tracer.js:4:12)\n    ' +
-      'at events.unhandledRejection (/opt/nodejs/node_modules/@lumigo/tracer/dist/tracer/tracer.js:264:73)\n    ' +
-      'at process.emit (node:events:519:28)\n    ' +
-      'at emitUnhandledRejection (node:internal/process/promises:250:13)\n    ' +
-      'at throwUnhandledRejectionsMode (node:internal/process/promises:385:19)';
-
-    const expectedStack =
-      'Error: Error: I am an error\n    ' +
-      'at new Promise (<anonymous>)\n    ' +
-      'at process.emit (node:events:519:28)\n    ' +
-      'at emitUnhandledRejection (node:internal/process/promises:250:13)\n    ' +
-      'at throwUnhandledRejectionsMode (node:internal/process/promises:385:19)';
-    const result = removeLumigoFromError(err.stack);
-
-    expect(result).toEqual(expectedStack);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -480,13 +480,6 @@ const isLumigoStackTrace = (input) => {
   return LUMIGO_STACK_PATTERNS.some((word) => word.test(input));
 };
 
-export const removeLumigoFromError = (stacktrace: string) => {
-  const stackArr = stacktrace.split('\n');
-
-  const cleanedStackArr = stackArr.filter((v) => !isLumigoStackTrace(v));
-
-  return cleanedStackArr.join('\n');
-};
 export const removeLumigoFromStacktrace = (handleReturnValue) => {
   // Note: this function was copied to the auto-instrument-handler. Keep them both up to date.
   try {
@@ -494,8 +487,12 @@ export const removeLumigoFromStacktrace = (handleReturnValue) => {
     if (!err || !err.stack) {
       return handleReturnValue;
     }
+    const { stack } = err;
+    const stackArr = stack.split('\n');
 
-    err.stack = removeLumigoFromError(err.stack);
+    const cleanedStack = stackArr.filter((v) => !isLumigoStackTrace(v));
+
+    err.stack = cleanedStack.join('\n');
 
     return { err, data, type };
   } catch (err) {


### PR DESCRIPTION
Reverts lumigo-io/lumigo-node#500