### PR TITLE
ci: move semantic-release before packing

### DIFF
--- a/scripts/bd_to_prod.sh
+++ b/scripts/bd_to_prod.sh
@@ -28,11 +28,14 @@ fi
 mkdir -p ~/.aws
 echo ${KEY} | gpg --batch -d --passphrase-fd 0 ${enc_location} > ~/.aws/credentials
 
+echo "Creating layer file to be included in the semantic-release"
+./scripts/prepare_layer_files.sh
+
 echo "Push to NPM"
 echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
 npm run semantic-release
 
-echo "Creating layer file"
+echo "Creating layer file again so the tarball will have the right version number"
 ./scripts/prepare_layer_files.sh
 
 echo "Creating lumigo-node layer"


### PR DESCRIPTION
**Description:** 
The version number for the tarballs shows as the previous version.
Steps to reproduce - If you download the latest layer, unzip it and look and the `package.json` file, you see (look at the `@lumigo/tracer` under dependencies) :
```
{
  "name": "nodejs",
  "version": "1.0.0",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "keywords": [],
  "author": "",
  "license": "ISC",
  "dependencies": {
    **"@lumigo/tracer": "file:../lumigo-tracer-1.99.2.tgz",**
    "lumigo-auto-instrument": "file:../auto-instrument-handler/lumigo-auto-instrument-1.0.0.tgz"
  },
  "description": ""
}
```
Note that we are on version **1.99.3**.
This confuses customers as this is also visible on the platform:

![image](https://github.com/user-attachments/assets/ba1dcb81-6fca-4fa0-91d6-29950c0a0b58)

**Solution**: 
Run the `prepare_layer_files` script before and after the `npm semantic-release` so that the changes will be included in the new version, and the tarball will have the correct version number. 

**Jira ticket:** 
See [RD-13077](https://lumigo.atlassian.net/browse/RD-13077). 

[RD-13077]: https://lumigo.atlassian.net/browse/RD-13077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ