### PR TITLE
fix: responseSteam crash

### DIFF
--- a/src/tracer/tracer.ts
+++ b/src/tracer/tracer.ts
@@ -128,7 +128,7 @@ export const trace =
     };
 
     if (isResponseStreamFunction) {
-      (decoratedUserHandler)[HANDLER_STREAMING] = STREAM_RESPONSE;
+      decoratedUserHandler[HANDLER_STREAMING] = STREAM_RESPONSE;
     }
     return decoratedUserHandler;
   };

--- a/src/tracer/tracer.ts
+++ b/src/tracer/tracer.ts
@@ -128,7 +128,7 @@ export const trace =
     };
 
     if (isResponseStreamFunction) {
-      (decoratedUserHandler as any)[HANDLER_STREAMING] = STREAM_RESPONSE;
+      (decoratedUserHandler)[HANDLER_STREAMING] = STREAM_RESPONSE;
     }
     return decoratedUserHandler;
   };

--- a/src/tracer/tracer.ts
+++ b/src/tracer/tracer.ts
@@ -52,9 +52,7 @@ export const LEAK_MESSAGE =
 export const trace =
   ({ token, debug, edgeHost, switchOff, stepFunction }: TraceOptions) =>
   (userHandler: Handler) => {
-    const isResponseStreamFunction =
-      userHandler[HANDLER_STREAMING] !== undefined &&
-      userHandler[HANDLER_STREAMING] === STREAM_RESPONSE;
+    const isResponseStreamFunction = userHandler[HANDLER_STREAMING] === STREAM_RESPONSE;
     const decoratedUserHandler = async <Event = any>(
       event: Event,
       context?: Context,

--- a/src/tracer/tracer.ts
+++ b/src/tracer/tracer.ts
@@ -40,6 +40,8 @@ import { TraceOptions } from './trace-options.type';
 import { GenericSpan } from '../types/spans/basicSpan';
 
 export const HANDLER_CALLBACKED = 'handler_callbacked';
+export const HANDLER_STREAMING = Symbol.for('aws.lambda.runtime.handler.streaming');
+export const STREAM_RESPONSE = 'response';
 export const ASYNC_HANDLER_RESOLVED = 'async_handler_resolved';
 export const ASYNC_HANDLER_REJECTED = 'async_handler_rejected';
 export const NON_ASYNC_HANDLER_ERRORED = 'non_async_errored';
@@ -49,70 +51,86 @@ export const LEAK_MESSAGE =
 
 export const trace =
   ({ token, debug, edgeHost, switchOff, stepFunction }: TraceOptions) =>
-  (userHandler: Handler) =>
-  async <Event = any>(event: Event, context?: Context, callback?: Callback): Promise<Handler> => {
-    if (!!switchOff || isSwitchedOff()) {
-      info(
-        `The '${SWITCH_OFF_FLAG}' environment variable is set to 'true': this invocation will not be traced by Lumigo`
-      );
-      return userHandler(event, context, callback);
-    }
+  (userHandler: Handler) => {
+    const isResponseStreamFunction =
+      userHandler[HANDLER_STREAMING] !== undefined &&
+      userHandler[HANDLER_STREAMING] === STREAM_RESPONSE;
+    const decoratedUserHandler = async <Event = any>(
+      event: Event,
+      context?: Context,
+      callback?: Callback
+    ): Promise<Handler> => {
+      if (!!switchOff || isSwitchedOff()) {
+        info(
+          `The '${SWITCH_OFF_FLAG}' environment variable is set to 'true': this invocation will not be traced by Lumigo`
+        );
+        return userHandler(event, context, callback);
+      }
 
-    if (!isAwsEnvironment()) {
-      warnClient('Tracer is disabled, running on non-aws environment');
-      return userHandler(event, context, callback);
-    }
+      if (!isAwsEnvironment()) {
+        warnClient('Tracer is disabled, running on non-aws environment');
+        return userHandler(event, context, callback);
+      }
+      if (isResponseStreamFunction) {
+        warnClient('Tracer is disabled, running on a response stream function');
+        return userHandler(event, context, callback);
+      }
+      try {
+        TracerGlobals.setHandlerInputs({ event, context });
+        TracerGlobals.setTracerInputs({
+          token,
+          debug,
+          edgeHost,
+          switchOff,
+          stepFunction,
+          lambdaTimeout: context.getRemainingTimeInMillis(),
+        });
+        ExecutionTags.autoTagEvent(event);
+      } catch (err) {
+        logger.warn('Failed to start tracer', err);
+      }
 
-    try {
-      TracerGlobals.setHandlerInputs({ event, context });
-      TracerGlobals.setTracerInputs({
-        token,
-        debug,
-        edgeHost,
-        switchOff,
-        stepFunction,
-        lambdaTimeout: context.getRemainingTimeInMillis(),
-      });
-      ExecutionTags.autoTagEvent(event);
-    } catch (err) {
-      logger.warn('Failed to start tracer', err);
-    }
+      if (!context || !isAwsContext(context)) {
+        logger.warnClient(
+          'missing context parameter - learn more at https://docs.lumigo.io/docs/nodejs'
+        );
+        const { err, data, type } = await promisifyUserHandler(userHandler, event, context);
+        return performPromisifyType(err, data, type, callback);
+      }
 
-    if (!context || !isAwsContext(context)) {
-      logger.warnClient(
-        'missing context parameter - learn more at https://docs.lumigo.io/docs/nodejs'
-      );
-      const { err, data, type } = await promisifyUserHandler(userHandler, event, context);
+      if (context.__wrappedByLumigo) {
+        const { err, data, type } = await promisifyUserHandler(userHandler, event, context);
+        return performPromisifyType(err, data, type, callback);
+      }
+      context.__wrappedByLumigo = true;
+
+      const functionSpan = getFunctionSpan(event, context);
+
+      await hookUnhandledRejection(functionSpan);
+
+      const pStartTrace = startTrace(functionSpan);
+      const pUserHandler = promisifyUserHandler(userHandler, event, context);
+
+      let [, handlerReturnValue] = await Promise.all([pStartTrace, pUserHandler]);
+
+      handlerReturnValue = normalizeLambdaError(handlerReturnValue);
+
+      if (isStepFunction()) {
+        handlerReturnValue = performStepFunctionLogic(handlerReturnValue);
+      }
+
+      const cleanedHandlerReturnValue = removeLumigoFromStacktrace(handlerReturnValue);
+
+      await endTrace(functionSpan, cleanedHandlerReturnValue);
+      const { err, data, type } = cleanedHandlerReturnValue;
+
       return performPromisifyType(err, data, type, callback);
+    };
+
+    if (isResponseStreamFunction) {
+      (decoratedUserHandler as any)[HANDLER_STREAMING] = STREAM_RESPONSE;
     }
-
-    if (context.__wrappedByLumigo) {
-      const { err, data, type } = await promisifyUserHandler(userHandler, event, context);
-      return performPromisifyType(err, data, type, callback);
-    }
-    context.__wrappedByLumigo = true;
-
-    const functionSpan = getFunctionSpan(event, context);
-
-    await hookUnhandledRejection(functionSpan);
-
-    const pStartTrace = startTrace(functionSpan);
-    const pUserHandler = promisifyUserHandler(userHandler, event, context);
-
-    let [, handlerReturnValue] = await Promise.all([pStartTrace, pUserHandler]);
-
-    handlerReturnValue = normalizeLambdaError(handlerReturnValue);
-
-    if (isStepFunction()) {
-      handlerReturnValue = performStepFunctionLogic(handlerReturnValue);
-    }
-
-    const cleanedHandlerReturnValue = removeLumigoFromStacktrace(handlerReturnValue);
-
-    await endTrace(functionSpan, cleanedHandlerReturnValue);
-    const { err, data, type } = cleanedHandlerReturnValue;
-
-    return performPromisifyType(err, data, type, callback);
+    return decoratedUserHandler;
   };
 
 export const startTrace = async (functionSpan: GenericSpan) => {


### PR DESCRIPTION
<!-- If this pull requests solves an issue, as an example, use `Closes #31`. #31 stands for the issue number -->

## Fixes Issue

Currently, if a lambda is of type `responseStream` (see [aws docs](https://aws.amazon.com/blogs/compute/introducing-aws-lambda-response-streaming/)) calling it with the tracer like so:

```javascript
import lumigo from '@lumigo/tracer';

const tracer = lumigo();

export const myHandler = awslambda.streamifyResponse(
  async (event, responseStream, context) => {
    responseStream.setContentType('text/plain');
    responseStream.write('Hello, world!');
    responseStream.end();
  }
);

export const handler = tracer.trace(myHandler);
```

will cause it to crash with:

```
"errorType": "TypeError",
"errorMessage": "responseStream.setContentType is not a function"
```

The issue here is that the when calling `tracer.trace(myHandler)` - the trace method is returning a decorated `myHandler`. That decorated function is not defined as a `responseStream` lambda, therefore AWS doesn't treat it as such and therefore it doesn't have a `responseStream` object. 

## Changes proposed

Check if the lambda is a responseStream lambda and if it is - disable the tracer and add mark the decorated handler as `responseStream`. We can do this by [mimicking the way AWS does it](https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/blob/db6a30da32934bcde91da248db30b60b17b891c4/src/UserFunction.js#L206). 

<!-- Check all the boxes which are applicable to check the box correct follow the following conventions -->
<!--
[x] - Correct
[X] - Correct
-->

## Check List (Check all the boxes which are applicable) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed. -> Opened a [PR for an integration test](https://github.com/lumigo-io/integration-tests/pull/1837) that should fail for this PR, and will be changed after.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Note to reviewers

The git diff went a bit crazy here - what I'm doing is changing the arrow function to be `decoratedUserHandler` so that I can mark it with `responseStream` if the `userHandler` is marked as `responseStream`.

Here is a simplified example of the tracer to explain my changes:
We currently do:
```javascript
export const traceGenerator = (traceOptions: TraceOptions) => {
  const trace = (userHandler: Handler) => { // trace is a decorator
    const decoratedUserHandler = async <Event = any>(event: Event, context?: Context, callback?: Callback): Promise<Handler> => {
     ... // tracer stuff
      return userHandler(event, context, callback);
    }
    return decoratedUserHandler;
  };
  return trace;
};
```

Instead, we will now do:

```javascript
export const traceGenerator = (traceOptions: TraceOptions) => {
  const trace = (userHandler: Handler) => { // trace is a decorator
    const decoratedUserHandler = async <Event = any>(event: Event, context?: Context, callback?: Callback): Promise<Handler> => {
      if (isResponseStreamFunction) {
        warnClient('Tracer is disabled, running on a response stream function');
        return userHandler(event, context, callback);
      }
      // otherwise continue to tracer stuff
      return userHandler(event, context, callback);
    }
    if (isResponseStreamFunction) {
      decoratedUserHandler[HANDLER_STREAMING] = STREAM_RESPONSE; // marking the decorated function as a responseStream
    }
    return decoratedUserHandler;
  };
  return trace;
};
```