### PR TITLE
fix: handle BigInt serialization

### DIFF
--- a/src/utils/payloadStringify.js
+++ b/src/utils/payloadStringify.js
@@ -194,6 +194,12 @@ export const payloadStringify = (
     const type = typeof value;
     const isObj = type === 'object';
     const isStr = type === 'string';
+    const isBigInt = type === 'bigint';
+
+    if (isBigInt) {
+      return value.toString();
+    }
+
     const shouldSkipSecretScrub =
       skipScrubPath &&
       skipScrubPath[skipScrubPath.length - 1] === key &&

--- a/src/utils/payloadStringify.test.js
+++ b/src/utils/payloadStringify.test.js
@@ -79,9 +79,8 @@ describe('payloadStringify', () => {
   test('handles BigInt', () => {
     const result = payloadStringify({ some: BigInt(345) });
 
-    expect(result).toEqual("{\"some\":\"345\"}");
+    expect(result).toEqual('{"some":"345"}');
   });
-
 
   test('payloadStringify -> truncate all', () => {
     const payload = { a: 2, b: 3 };

--- a/src/utils/payloadStringify.test.js
+++ b/src/utils/payloadStringify.test.js
@@ -76,6 +76,13 @@ describe('payloadStringify', () => {
     expect(result).toEqual('');
   });
 
+  test('handles BigInt', () => {
+    const result = payloadStringify({ some: BigInt(345) });
+
+    expect(result).toEqual("{\"some\":\"345\"}");
+  });
+
+
   test('payloadStringify -> truncate all', () => {
     const payload = { a: 2, b: 3 };
 


### PR DESCRIPTION
## Fixes Issue

Addresses the issue from this [thread](https://lumigo-io.slack.com/archives/C015YUW8U91/p1725386720497649), where the tracer fails when the event payload includes a `BigInt` value.

## Changes proposed

Serialize the value as a numeric string