### PR TITLE
fix: support new x ray format nodejs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
     environment:
       - TZ: Asia/Jerusalem
       - NODE_OPTIONS: --max_old_space_size=1500
-    resource_class: medium+
+    resource_class: large
     working_directory: ~/lumigo-node
     steps:
       - run:

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -181,6 +181,11 @@ describe('utils', () => {
     ${'Root=1-5b1d2450-6ac46730d346cad0e53f89d0'}                                                        | ${{ Root: '1-5b1d2450-6ac46730d346cad0e53f89d0' }}
     ${'Root=1-670d0060-1b85fdcd75ed1c2557382245;Lineage=1:aba0be3a:0'}                                   | ${{ Root: '1-670d0060-1b85fdcd75ed1c2557382245', Lineage: '1:aba0be3a:0' }}
     ${'Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Parent=59fa1aeb03c2ec1f;Sampled=1;Lineage=1:aba0be3a:0'} | ${{ Root: '1-5b1d2450-6ac46730d346cad0e53f89d0', Parent: '59fa1aeb03c2ec1f', Sampled: '1', Lineage: '1:aba0be3a:0' }}
+    ${';;;;;;;;;'}                                                                                       | ${{}}
+    ${''}                                                                                                | ${{}}
+    ${'========='}                                                                                       | ${{}}
+    ${'=;=;=;=;'}                                                                                        | ${{}}
+    ${';;;;;===='}                                                                                       | ${{}}
   `('splitXrayTraceIdToFields', ({ xrayTraceId, expected }) => {
     expect(utils.splitXrayTraceIdToFields(xrayTraceId)).toEqual(expected);
   });

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -162,7 +162,12 @@ describe('utils', () => {
     });
 
     // The x-ray value is too long, too many fields. We should parse it as usual
-const longXrayId = ['Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Parent=59fa1aeb03c2ec1f;Sampled=1', ...Array(1000).fill(0).map((_, i) => `${i}=${i}`)].join(';')
+    const longXrayId = [
+      'Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Parent=59fa1aeb03c2ec1f;Sampled=1',
+      ...Array(1000)
+        .fill(0)
+        .map((_, i) => `${i}=${i}`),
+    ].join(';');
     expect(utils.getTraceId(longXrayId)).toEqual({
       Parent: '59fa1aeb03c2ec1f',
       Root: '1-5b1d2450-6ac46730d346cad0e53f89d0',
@@ -188,10 +193,10 @@ const longXrayId = ['Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Parent=59fa1aeb03c
   });
 
   test('splitXrayTraceIdToFields - too many fields', () => {
-    let longXrayId = '0=0';
-    for (let i = 1; i < 1000; i++) {
-      longXrayId += `;${i}=${i}`;
-    }
+    let longXrayId = Array(1000)
+      .fill(0)
+      .map((_, i) => `${i}=${i}`)
+      .join(';');
 
     const expectedFields = {};
     for (let i = 0; i < 100; i++) {

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -84,62 +84,62 @@ describe('utils', () => {
   });
 
   test('getTraceId', () => {
-    // const awsXAmznTraceId =
-    //   'Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Parent=59fa1aeb03c2ec1f;Sampled=1';
-    // const expected = {
-    //   Parent: '59fa1aeb03c2ec1f',
-    //   Root: '1-5b1d2450-6ac46730d346cad0e53f89d0',
-    //   Sampled: '1',
-    //   transactionId: '6ac46730d346cad0e53f89d0',
-    // };
-    // expect(utils.getTraceId(awsXAmznTraceId)).toEqual(expected);
-    //
-    // const awsXAmznLineageParentTraceId =
-    //   'Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Sampled=1;Parent=59fa1aeb03c2ec1f;Lineage=a87bd80c:1|68fd508a:5|c512fbe3:2';
-    // const LineageParentExpected = {
-    //   Parent: '59fa1aeb03c2ec1f',
-    //   Root: '1-5b1d2450-6ac46730d346cad0e53f89d0',
-    //   Sampled: '1',
-    //   transactionId: '6ac46730d346cad0e53f89d0',
-    //   Lineage: 'a87bd80c:1|68fd508a:5|c512fbe3:2',
-    // };
-    // expect(utils.getTraceId(awsXAmznLineageParentTraceId)).toEqual(LineageParentExpected);
-    //
-    // const awsXAmznLineageNoParentTraceId =
-    //   'Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Sampled=1;Lineage=a87bd80c:1|68fd508a:5|c512fbe3:2\n';
-    // const lineageNoParentActual = utils.getTraceId(awsXAmznLineageNoParentTraceId);
-    // expect(lineageNoParentActual.Root).toEqual('1-5b1d2450-6ac46730d346cad0e53f89d0');
-    // expect(lineageNoParentActual.transactionId).toEqual('6ac46730d346cad0e53f89d0');
-    // expect(lineageNoParentActual.Parent).toBeTruthy();
-    //
-    // expect(utils.getTraceId(null)).toEqual({
-    //   Root: 'f585f41',
-    //   Parent: '5f585f414d5a4e5f54524143',
-    //   Sampled: '1',
-    //   transactionId: '5f585f414d5a4e5f54524143',
-    // });
-    //
-    // expect(utils.getTraceId('x;y')).toEqual({
-    //   Root: '83b7978',
-    //   Parent: '783b79783b79783b79783b79',
-    //   Sampled: '1',
-    //   transactionId: '783b79783b79783b79783b79',
-    // });
-    //
-    // expect(utils.getTraceId('a=b;c=d;e=f')).toEqual({
-    //   Root: '13d623b',
-    //   Parent: '613d623b633d643b653d6661',
-    //   Sampled: '1',
-    //   transactionId: '613d623b633d643b653d6661',
-    // });
-    //
-    // const fields = utils.getTraceId(
-    //   'Root=1-670d0060-1b85fdcd75ed1c2557382245;Lineage=1:aba0be3a:0'
-    // );
-    // expect(fields.Root).toEqual('1-670d0060-1b85fdcd75ed1c2557382245');
-    // expect(fields.transactionId).toEqual('1b85fdcd75ed1c2557382245');
-    // expect(fields.Lineage).toEqual('1:aba0be3a:0');
-    // expect(fields.Parent).toBeTruthy();
+    const awsXAmznTraceId =
+      'Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Parent=59fa1aeb03c2ec1f;Sampled=1';
+    const expected = {
+      Parent: '59fa1aeb03c2ec1f',
+      Root: '1-5b1d2450-6ac46730d346cad0e53f89d0',
+      Sampled: '1',
+      transactionId: '6ac46730d346cad0e53f89d0',
+    };
+    expect(utils.getTraceId(awsXAmznTraceId)).toEqual(expected);
+
+    const awsXAmznLineageParentTraceId =
+      'Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Sampled=1;Parent=59fa1aeb03c2ec1f;Lineage=a87bd80c:1|68fd508a:5|c512fbe3:2';
+    const LineageParentExpected = {
+      Parent: '59fa1aeb03c2ec1f',
+      Root: '1-5b1d2450-6ac46730d346cad0e53f89d0',
+      Sampled: '1',
+      transactionId: '6ac46730d346cad0e53f89d0',
+      Lineage: 'a87bd80c:1|68fd508a:5|c512fbe3:2',
+    };
+    expect(utils.getTraceId(awsXAmznLineageParentTraceId)).toEqual(LineageParentExpected);
+
+    const awsXAmznLineageNoParentTraceId =
+      'Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Sampled=1;Lineage=a87bd80c:1|68fd508a:5|c512fbe3:2\n';
+    const lineageNoParentActual = utils.getTraceId(awsXAmznLineageNoParentTraceId);
+    expect(lineageNoParentActual.Root).toEqual('1-5b1d2450-6ac46730d346cad0e53f89d0');
+    expect(lineageNoParentActual.transactionId).toEqual('6ac46730d346cad0e53f89d0');
+    expect(lineageNoParentActual.Parent).toBeTruthy();
+
+    expect(utils.getTraceId(null)).toEqual({
+      Root: 'f585f41',
+      Parent: '5f585f414d5a4e5f54524143',
+      Sampled: '1',
+      transactionId: '5f585f414d5a4e5f54524143',
+    });
+
+    expect(utils.getTraceId('x;y')).toEqual({
+      Root: '83b7978',
+      Parent: '783b79783b79783b79783b79',
+      Sampled: '1',
+      transactionId: '783b79783b79783b79783b79',
+    });
+
+    expect(utils.getTraceId('a=b;c=d;e=f')).toEqual({
+      Root: '13d623b',
+      Parent: '613d623b633d643b653d6661',
+      Sampled: '1',
+      transactionId: '613d623b633d643b653d6661',
+    });
+
+    const fields = utils.getTraceId(
+      'Root=1-670d0060-1b85fdcd75ed1c2557382245;Lineage=1:aba0be3a:0'
+    );
+    expect(fields.Root).toEqual('1-670d0060-1b85fdcd75ed1c2557382245');
+    expect(fields.transactionId).toEqual('1b85fdcd75ed1c2557382245');
+    expect(fields.Lineage).toEqual('1:aba0be3a:0');
+    expect(fields.Parent).toBeTruthy();
 
     // Invalid root value, the new parser should fail and then be handled by the legacy parser
     const invalidRootTraceId = 'Root=6ac46730d346cad0e53f89d0;Parent=59fa1aeb03c2ec1f;Sampled=1';
@@ -160,6 +160,45 @@ describe('utils', () => {
       Sampled: '1',
       transactionId: '526f6f743d36616334363733',
     });
+
+    // The x-ray value is too long, too many fields. We should parse it as usual
+    let longXrayId = 'Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Parent=59fa1aeb03c2ec1f;Sampled=1';
+    for (let i = 0; i < 1000; i++) {
+      longXrayId += `;${i}=${i}`;
+    }
+    expect(utils.getTraceId(longXrayId)).toEqual({
+      Parent: '59fa1aeb03c2ec1f',
+      Root: '1-5b1d2450-6ac46730d346cad0e53f89d0',
+      Sampled: '1',
+      transactionId: '6ac46730d346cad0e53f89d0',
+    });
+  });
+
+  test.each`
+    xrayTraceId                                                                                          | expected
+    ${'Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Parent=59fa1aeb03c2ec1f;Sampled=1'}                      | ${{ Root: '1-5b1d2450-6ac46730d346cad0e53f89d0', Parent: '59fa1aeb03c2ec1f', Sampled: '1' }}
+    ${'Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Parent=59fa1aeb03c2ec1f'}                                | ${{ Root: '1-5b1d2450-6ac46730d346cad0e53f89d0', Parent: '59fa1aeb03c2ec1f' }}
+    ${'Root=1-5b1d2450-6ac46730d346cad0e53f89d0'}                                                        | ${{ Root: '1-5b1d2450-6ac46730d346cad0e53f89d0' }}
+    ${'Root=1-670d0060-1b85fdcd75ed1c2557382245;Lineage=1:aba0be3a:0'}                                   | ${{ Root: '1-670d0060-1b85fdcd75ed1c2557382245', Lineage: '1:aba0be3a:0' }}
+    ${'Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Parent=59fa1aeb03c2ec1f;Sampled=1;Lineage=1:aba0be3a:0'} | ${{ Root: '1-5b1d2450-6ac46730d346cad0e53f89d0', Parent: '59fa1aeb03c2ec1f', Sampled: '1', Lineage: '1:aba0be3a:0' }}
+  `('splitXrayTraceIdToFields', ({ xrayTraceId, expected }) => {
+    expect(utils.splitXrayTraceIdToFields(xrayTraceId)).toEqual(expected);
+  });
+
+  test('splitXrayTraceIdToFields - too many fields', () => {
+    let longXrayId = '0=0';
+    for (let i = 1; i < 1000; i++) {
+      longXrayId += `;${i}=${i}`;
+    }
+
+    const expectedFields = {};
+    for (let i = 0; i < 100; i++) {
+      expectedFields[`${i}`] = `${i}`;
+    }
+
+    const fields = utils.splitXrayTraceIdToFields(longXrayId);
+
+    expect(fields).toEqual(expectedFields);
   });
 
   test('isObject', () => {

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -84,62 +84,82 @@ describe('utils', () => {
   });
 
   test('getTraceId', () => {
-    const awsXAmznTraceId =
-      'Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Parent=59fa1aeb03c2ec1f;Sampled=1';
-    const expected = {
+    // const awsXAmznTraceId =
+    //   'Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Parent=59fa1aeb03c2ec1f;Sampled=1';
+    // const expected = {
+    //   Parent: '59fa1aeb03c2ec1f',
+    //   Root: '1-5b1d2450-6ac46730d346cad0e53f89d0',
+    //   Sampled: '1',
+    //   transactionId: '6ac46730d346cad0e53f89d0',
+    // };
+    // expect(utils.getTraceId(awsXAmznTraceId)).toEqual(expected);
+    //
+    // const awsXAmznLineageParentTraceId =
+    //   'Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Sampled=1;Parent=59fa1aeb03c2ec1f;Lineage=a87bd80c:1|68fd508a:5|c512fbe3:2';
+    // const LineageParentExpected = {
+    //   Parent: '59fa1aeb03c2ec1f',
+    //   Root: '1-5b1d2450-6ac46730d346cad0e53f89d0',
+    //   Sampled: '1',
+    //   transactionId: '6ac46730d346cad0e53f89d0',
+    //   Lineage: 'a87bd80c:1|68fd508a:5|c512fbe3:2',
+    // };
+    // expect(utils.getTraceId(awsXAmznLineageParentTraceId)).toEqual(LineageParentExpected);
+    //
+    // const awsXAmznLineageNoParentTraceId =
+    //   'Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Sampled=1;Lineage=a87bd80c:1|68fd508a:5|c512fbe3:2\n';
+    // const lineageNoParentActual = utils.getTraceId(awsXAmznLineageNoParentTraceId);
+    // expect(lineageNoParentActual.Root).toEqual('1-5b1d2450-6ac46730d346cad0e53f89d0');
+    // expect(lineageNoParentActual.transactionId).toEqual('6ac46730d346cad0e53f89d0');
+    // expect(lineageNoParentActual.Parent).toBeTruthy();
+    //
+    // expect(utils.getTraceId(null)).toEqual({
+    //   Root: 'f585f41',
+    //   Parent: '5f585f414d5a4e5f54524143',
+    //   Sampled: '1',
+    //   transactionId: '5f585f414d5a4e5f54524143',
+    // });
+    //
+    // expect(utils.getTraceId('x;y')).toEqual({
+    //   Root: '83b7978',
+    //   Parent: '783b79783b79783b79783b79',
+    //   Sampled: '1',
+    //   transactionId: '783b79783b79783b79783b79',
+    // });
+    //
+    // expect(utils.getTraceId('a=b;c=d;e=f')).toEqual({
+    //   Root: '13d623b',
+    //   Parent: '613d623b633d643b653d6661',
+    //   Sampled: '1',
+    //   transactionId: '613d623b633d643b653d6661',
+    // });
+    //
+    // const fields = utils.getTraceId(
+    //   'Root=1-670d0060-1b85fdcd75ed1c2557382245;Lineage=1:aba0be3a:0'
+    // );
+    // expect(fields.Root).toEqual('1-670d0060-1b85fdcd75ed1c2557382245');
+    // expect(fields.transactionId).toEqual('1b85fdcd75ed1c2557382245');
+    // expect(fields.Lineage).toEqual('1:aba0be3a:0');
+    // expect(fields.Parent).toBeTruthy();
+
+    // Invalid root value, the new parser should fail and then be handled by the legacy parser
+    const invalidRootTraceId = 'Root=6ac46730d346cad0e53f89d0;Parent=59fa1aeb03c2ec1f;Sampled=1';
+    expect(utils.getTraceId(invalidRootTraceId)).toEqual({
       Parent: '59fa1aeb03c2ec1f',
-      Root: '1-5b1d2450-6ac46730d346cad0e53f89d0',
+      Root: '6ac46730d346cad0e53f89d0',
       Sampled: '1',
-      transactionId: '6ac46730d346cad0e53f89d0',
-    };
-    expect(utils.getTraceId(awsXAmznTraceId)).toEqual(expected);
-
-    const awsXAmznLineageParentTraceId =
-      'Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Sampled=1;Parent=59fa1aeb03c2ec1f;Lineage=a87bd80c:1|68fd508a:5|c512fbe3:2';
-    const LineageParentExpected = {
-      Parent: '59fa1aeb03c2ec1f',
-      Root: '1-5b1d2450-6ac46730d346cad0e53f89d0',
-      Sampled: '1',
-      transactionId: '6ac46730d346cad0e53f89d0',
-      Lineage: 'a87bd80c:1|68fd508a:5|c512fbe3:2',
-    };
-    expect(utils.getTraceId(awsXAmznLineageParentTraceId)).toEqual(LineageParentExpected);
-
-    const awsXAmznLineageNoParentTraceId =
-      'Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Sampled=1;Lineage=a87bd80c:1|68fd508a:5|c512fbe3:2\n';
-    const lineageNoParentActual = utils.getTraceId(awsXAmznLineageNoParentTraceId);
-    expect(lineageNoParentActual.Root).toEqual('1-5b1d2450-6ac46730d346cad0e53f89d0');
-    expect(lineageNoParentActual.transactionId).toEqual('6ac46730d346cad0e53f89d0');
-    expect(lineageNoParentActual.Parent).toBeTruthy();
-
-    expect(utils.getTraceId(null)).toEqual({
-      Root: 'f585f41',
-      Parent: '5f585f414d5a4e5f54524143',
-      Sampled: '1',
-      transactionId: '5f585f414d5a4e5f54524143',
+      // Note: the current implementation splits the root by `-` and uses the third part as the transactionId. If there isn't a third part it sets it as undefined.
+      transactionId: undefined,
     });
 
-    expect(utils.getTraceId('x;y')).toEqual({
-      Root: '83b7978',
-      Parent: '783b79783b79783b79783b79',
+    // Invalid root value, the new parser should fail and then be handled by the legacy parser
+    const invalidAndShortTraceId = 'Root=6ac46730d346cad0e53f89d0';
+    expect(utils.getTraceId(invalidAndShortTraceId)).toEqual({
+      // Static values generated based on the x-ray trace id value
+      Parent: '526f6f743d36616334363733',
+      Root: '26f6f74',
       Sampled: '1',
-      transactionId: '783b79783b79783b79783b79',
+      transactionId: '526f6f743d36616334363733',
     });
-
-    expect(utils.getTraceId('a=b;c=d;e=f')).toEqual({
-      Root: '13d623b',
-      Parent: '613d623b633d643b653d6661',
-      Sampled: '1',
-      transactionId: '613d623b633d643b653d6661',
-    });
-
-    const fields = utils.getTraceId(
-      'Root=1-670d0060-1b85fdcd75ed1c2557382245;Lineage=1:aba0be3a:0'
-    );
-    expect(fields.Root).toEqual('1-670d0060-1b85fdcd75ed1c2557382245');
-    expect(fields.transactionId).toEqual('1b85fdcd75ed1c2557382245');
-    expect(fields.Lineage).toEqual('1:aba0be3a:0');
-    expect(fields.Parent).toBeTruthy();
   });
 
   test('isObject', () => {

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -162,10 +162,7 @@ describe('utils', () => {
     });
 
     // The x-ray value is too long, too many fields. We should parse it as usual
-    let longXrayId = 'Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Parent=59fa1aeb03c2ec1f;Sampled=1';
-    for (let i = 0; i < 1000; i++) {
-      longXrayId += `;${i}=${i}`;
-    }
+const longXrayId = ['Root=1-5b1d2450-6ac46730d346cad0e53f89d0;Parent=59fa1aeb03c2ec1f;Sampled=1', ...Array(1000).fill(0).map((_, i) => `${i}=${i}`)].join(';')
     expect(utils.getTraceId(longXrayId)).toEqual({
       Parent: '59fa1aeb03c2ec1f',
       Root: '1-5b1d2450-6ac46730d346cad0e53f89d0',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -135,7 +135,7 @@ export const getNewFormatTraceId = (awsXAmznTraceId: string): xRayTraceIdFields 
   const transactionId = fields.Root.split('-')[2];
   // Note: we might not need to generate a Parent field if it's not present,
   // but for now we'll keep it as is to minimize changes. The python tracer doesn't generate it FYI.
-  const { Parent: parent = getRandomString(16), Sampled: sampled,  Lineage: lineage } = fields;
+  const { Parent: parent = getRandomString(16), Sampled: sampled, Lineage: lineage } = fields;
 
   const parsedTraceId: xRayTraceIdFields = {
     Root: root,
@@ -250,7 +250,7 @@ export const getPatchedTraceId = (awsXAmznTraceId): string => {
   const { Root, Parent, Sampled, transactionId, Lineage } = getTraceId(awsXAmznTraceId);
   const rootArr = Root.split('-');
   const currentTime = Math.floor(Date.now() / 1000).toString(16);
-  const patchedTraceId = [`Root=${rootArr[0]}-${currentTime}-${transactionId}`, `Parent=${Parent}`]
+  const patchedTraceId = [`Root=${rootArr[0]}-${currentTime}-${transactionId}`, `Parent=${Parent}`];
   if (Sampled) {
     patchedTraceId.push(`Sampled=${Sampled}`);
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -107,7 +107,7 @@ export const getTracerInfo = (): { name: string; version: string } => {
 
 const xRayFieldKeyValuePattern = /([^=;]+)=([^;]*)/g;
 
-const splitXrayTraceIdToFields = (
+export const splitXrayTraceIdToFields = (
   awsXAmznTraceId: string,
   maxFields: number = 100
 ): { [key: string]: string } => {
@@ -134,14 +134,6 @@ const splitXrayTraceIdToFields = (
     // Increment iteration counter
     iterations++;
   }
-
-  // Add default handling for known keys in case they're missing
-  const expectedKeys = ['Root', 'Parent', 'Sampled'];
-  expectedKeys.forEach((key) => {
-    if (!(key in result)) {
-      result[key] = null;
-    }
-  });
 
   // If maxIterations is reached, we can log a warning or handle it as needed
   if (iterations >= maxFields) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -105,42 +105,17 @@ export const getTracerInfo = (): { name: string; version: string } => {
   return { name, version };
 };
 
-const xRayFieldKeyValuePattern = /([^=;]+)=([^;]*)/g;
+const xRayFieldKeyValuePattern = /([^;=]+)=([^;=]+)/g;
 
 export const splitXrayTraceIdToFields = (
   awsXAmznTraceId: string,
   maxFields: number = 100
 ): { [key: string]: string } => {
-  const result: { [key: string]: string | null } = {};
-  let match: RegExpExecArray | null;
-  let iterations = 0;
-
-  // Resetting the regex lastIndex to ensure it works correctly for different inputs
-  xRayFieldKeyValuePattern.lastIndex = 0;
-
-  // Iterate over each match of the pattern in the string with a limit to avoid infinite loop
-  while (
-    (match = xRayFieldKeyValuePattern.exec(awsXAmznTraceId)) !== null &&
-    iterations < maxFields
-  ) {
-    const key = match[1].trim();
-    const value = match[2].trim();
-
-    // Ensure key is valid and not empty, assign null if value is not present
-    if (key) {
-      result[key] = value ? value : null;
-    }
-
-    // Increment iteration counter
-    iterations++;
-  }
-
-  // If maxIterations is reached, we can log a warning or handle it as needed
-  if (iterations >= maxFields) {
-    console.warn(`Reached maximum iteration limit of ${maxFields} while parsing X-Ray trace ID`);
-  }
-
-  return result;
+  const matches = Array.from(awsXAmznTraceId.matchAll(xRayFieldKeyValuePattern)).slice(
+    0,
+    maxFields
+  );
+  return Object.fromEntries(matches.map((match) => [match[1], match[2]]));
 };
 
 export const getNewFormatTraceId = (awsXAmznTraceId: string): xRayTraceIdFields => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -252,14 +252,14 @@ export const getPatchedTraceId = (awsXAmznTraceId): string => {
   const { Root, Parent, Sampled, transactionId, Lineage } = getTraceId(awsXAmznTraceId);
   const rootArr = Root.split('-');
   const currentTime = Math.floor(Date.now() / 1000).toString(16);
-  let patchedTraceId = `Root=${rootArr[0]}-${currentTime}-${transactionId};Parent=${Parent}`;
+  const patchedTraceId = [`Root=${rootArr[0]}-${currentTime}-${transactionId}`, `Parent=${Parent}`]
   if (Sampled) {
-    patchedTraceId += `;Sampled=${Sampled}`;
+    patchedTraceId.push(`Sampled=${Sampled}`);
   }
   if (Lineage) {
-    patchedTraceId += `;Lineage=${Lineage}`;
+    patchedTraceId.push(`Lineage=${Lineage}`);
   }
-  return patchedTraceId;
+  return patchedTraceId.join(';');
 };
 
 export const isPromise = (obj: any): boolean => typeof obj?.then === 'function';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -135,9 +135,7 @@ export const getNewFormatTraceId = (awsXAmznTraceId: string): xRayTraceIdFields 
   const transactionId = fields.Root.split('-')[2];
   // Note: we might not need to generate a Parent field if it's not present,
   // but for now we'll keep it as is to minimize changes. The python tracer doesn't generate it FYI.
-  const parent = fields.Parent || getRandomString(16);
-  const sampled = fields.Sampled;
-  const lineage = fields.Lineage;
+  const { Parent: parent = getRandomString(16), Sampled: sampled,  Lineage: lineage } = fields;
 
   const parsedTraceId: xRayTraceIdFields = {
     Root: root,


### PR DESCRIPTION
## Fixes Issue

AWS is planning on releasing a change to the format of the X-Ray Trace ID value, and we need to support the new format (And the old one to support the transition phase).

AWS is removing the `Parent` and `Sampled` fields from any lambda that is set to passive tracing (the default).
The old format is:
```
Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1;Lineage=a87bd80c:1|68fd508a:5|c512fbe3:2
```

And the new format will be:
```
Root=1-5759e988-bd862e3fe1be46a994272793;Lineage=a87bd80c:1|68fd508a:5|c512fbe3:2
```

Notes:
* We use the `Root` value for the transaction id value (The last part splitting by `-`)
* We don't use the `Parent` field in the tracer code for anything except adding it to the lambda invocation http span `traceId` json. The python tracer doesn't add this field to the span, so I suspect it isn't used
* Parsing the x ray trace-id is crucial for the tracer to work, we had a bug with this parsing a year ago that caused the customers lambda to crash once the traceId format changed... need to be carful here