### PR TITLE
fix: form-data vulnerability GHSA-fjxv-7rqg-78g

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3193,9 +3193,9 @@
       }
     },
     "axios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -4799,13 +4799,14 @@
       }
     },
     "form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3193,12 +3193,12 @@
       }
     },
     "axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
       "requires": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@lumigo/node-core": "1.17.1",
     "agentkeepalive": "^4.1.4",
-    "axios": "1.8.4",
+    "axios": "1.10.0",
     "rfdc": "^1.4.1",
     "shimmer": "1.2.1",
     "utf8": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@lumigo/node-core": "1.17.1",
     "agentkeepalive": "^4.1.4",
-    "axios": "1.10.0",
+    "axios": "^1.11.0",
     "rfdc": "^1.4.1",
     "shimmer": "1.2.1",
     "utf8": "^3.0.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "moduleResolution": "node",
     "experimentalDecorators": true,
     "resolveJsonModule": true,
-    "lib": ["esnext"]
+    "lib": ["esnext", "dom"]
   },
   "include": ["./src/**/*"],
   "exclude": ["**/*.test.js", "**/*.test.ts", "__mocks__", "./testUtils"]


### PR DESCRIPTION
```
NAME       INSTALLED  FIXED IN  TYPE  VULNERABILITY        SEVERITY  EPSS           RISK   
form-data  4.0.2      4.0.4     npm   GHSA-fjxv-7rqg-78g4  Critical  < 0.1% (12th)  < 0.1
```
running:
```
npm ls form-data
```
shows that `axios` is the one bringing that dependency:
```
@lumigo/tracer@1.108.0 /Users/harelmoshe/source/lumigo-node
└─┬ axios@1.8.4
  └── form-data@4.0.2
```