### PR TITLE
feat: Enable Slack notifications for daily vulnerability scan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,8 @@ workflows:
       - lumigo-orb/vulnerability-scan:
           name: daily-vulnerability-scan
           context: common
+          notify_on_failure: true
+          failure_notification_message: "Daily vulnerability scan failed for lumigo-node."
           pre_scan_command: |
             npm ci && pushd auto-instrument-handler && npm install && popd
           targets_file: ./grype_targets.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ workflows:
           name: daily-vulnerability-scan
           context: common
           notify_on_failure: true
-          failure_notification_message: "Daily vulnerability scan failed for lumigo-node."
+          failure_notification_message: "Daily vulnerability scan failed for lumigo-node"
           pre_scan_command: |
             npm ci && pushd auto-instrument-handler && npm install && popd
           targets_file: ./grype_targets.txt


### PR DESCRIPTION
## Summary
Author: Eugene Orlovsky

Adds `notify_on_failure` and `failure_notification_message` parameters to the daily vulnerability scan workflow so that Slack notifications are sent when the scan fails.

**Note:** This depends on the lumigo-orb PR that adds `notify_on_failure` support to the `vulnerability-scan` job.