### PR TITLE
feat: notify Dash0 Slack on vulnerability-scan failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,7 @@ workflows:
           name: daily-vulnerability-scan
           context: common
           notify_on_failure: true
+          notify_dash0_on_failure: true
           failure_notification_message: "Daily vulnerability scan failed for lumigo-node"
           pre_scan_command: |
             npm ci && pushd auto-instrument-handler && npm install && popd


### PR DESCRIPTION
## Summary
- Sets `notify_dash0_on_failure: true` on the `daily-vulnerability-scan` workflow so failures are also posted to Dash0's `#lumigo-security-scans` channel.
- PR-time vulnerability scan is intentionally unchanged — it stays silent (the failing CircleCI check on the PR is the signal).

## Context
Linear: [CLO-643](https://linear.app/dash0/issue/CLO-643/send-vulnerability-alerts-from-lumigo-to-dash0-slack).
