### PR TITLE
[DO NOT MERGE] smoke test Dash0 webhook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,10 @@ workflows:
 
     - lumigo-orb/vulnerability-scan:
         context: common
+        min_fail_severity: negligible
+        notify_on_failure: true
+        notify_dash0_on_failure: true
+        failure_notification_message: "TEST: Dash0 webhook smoke test from lumigo-node — please ignore"
         pre_scan_command: |
           npm ci && pushd auto-instrument-handler && npm install && popd
         targets_file: ./grype_targets.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,12 +69,12 @@ workflows:
 
     - lumigo-orb/vulnerability-scan:
         context: common
-        min_fail_severity: negligible
         notify_on_failure: true
         notify_dash0_on_failure: true
         failure_notification_message: "TEST: Dash0 webhook smoke test from lumigo-node — please ignore"
         pre_scan_command: |
-          npm ci && pushd auto-instrument-handler && npm install && popd
+          echo "Forcing failure to test Slack notification path"
+          exit 1
         targets_file: ./grype_targets.txt
 
     - lumigo-orb/workflow-completed-successfully:


### PR DESCRIPTION
Throwaway branch to verify the Dash0 Slack webhook end-to-end after merging #558. Forces `min_fail_severity: negligible` so Grype always fails. Will be closed and deleted after Slack messages are confirmed in both Lumigo `#ci-cd-alerts` and Dash0 `#lumigo-security-scans`. Author: Eugene Orlovsky