### PR TITLE
fix: upgrade form-data to 4.0.6 to address GHSA-hmw2-7cc7-3qxx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4799,15 +4799,15 @@
       }
     },
     "form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       }
     },
     "from2": {
@@ -5202,9 +5202,9 @@
       }
     },
     "hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "requires": {
         "function-bind": "^1.1.2"
       },


### PR DESCRIPTION
## What

Resolves the High-severity advisory **GHSA-hmw2-7cc7-3qxx** flagged by the vulnerability scan.

- **form-data** `4.0.5` → `4.0.6` (patched version; transitive via `axios@1.16.0`, which already accepts `^4.0.5`)
- **hasown** `2.0.3` → `2.0.4` — form-data 4.0.6 raised its requirement to `hasown@^2.0.4`; 2.0.4 also satisfies all other `^2.0.2` requirers
- `mime-types` was already at `2.1.35`, satisfying form-data 4.0.6's bumped `^2.1.35` requirement

## Notes

- `package.json` is unchanged — form-data is a transitive dependency.
- The lockfile was edited in place (with registry integrity hashes) to **preserve `lockfileVersion: 1`**. Running `npm install` directly would have rewritten the entire file to lockfileVersion 3 (~10k-line diff).
- Validated lockfile consistency with `npm install --package-lock-only` against a throwaway copy — no resolution/integrity errors.