### PR TITLE
fix: prevent master deploy OOM during npm publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,7 @@ jobs:
     <<: *defaults
     environment:
       - TZ: Asia/Jerusalem
+      - NODE_OPTIONS: --max_old_space_size=1500
     resource_class: medium+
     working_directory: ~/lumigo-node
     steps:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "jest-detectOpenHandles": "jest --detectOpenHandles",
     "jest-traces": "node --trace-deprecation --trace-warnings node_modules/.bin/jest",
     "lint": "eslint ./src",
-    "prepublishOnly": "npm run lint && npm run prettier:fix && npm run test",
+    "prepublishOnly": "npm run build",
     "prettier:ci": "prettier --list-different \"src/**/*.[jt]s\" --parser typescript",
     "prettier:fix": "prettier --write \"./src/**/*.[jt]s\" --parser typescript",
     "semantic-release": "semantic-release",


### PR DESCRIPTION
## Problem

The master `deploy` job has been silently failing during `semantic-release`'s npm publish. The job log stops abruptly mid-`jest` with no error, no jest summary, and no publish line — the signature of a **killed process (OOM, exit 137)**, not a command error.

**Impact:** the npm publish never completes. `1.111.0` and `1.111.1` were tagged in git but **never published to npm** — the registry `latest` is still `1.110.2`. semantic-release pushes the version commit + tag during its `prepare` phase (before `publish`), so git/tags ran ahead of the registry while the actual publish died.

## Root cause

`prepublishOnly` re-ran the entire `lint + prettier:fix + build + jest` suite during `npm publish`. The `deploy` job — unlike `test` and `test-18` — did **not** set `NODE_OPTIONS=--max_old_space_size`, so the full jest run used the default Node heap and got OOM-killed.

## Fix

- **`prepublishOnly` → `npm run build`.** Lint, prettier, type-check, and tests already run in the dedicated `test` / `test-18` CI jobs on PRs, so re-running the whole suite during the production publish was redundant — and `prettier:fix` was mutating files mid-publish. The publish still builds fresh `dist/` before packing.
- **Add `NODE_OPTIONS=--max_old_space_size=1500` to the `deploy` job**, mirroring the test jobs, as headroom for the build step.

## Note

The orphaned `v1.111.0` / `v1.111.1` tags (tagged but unpublished) are intentionally **not** recovered here — npm `latest` stays at `1.110.2` and the next release will cut a fresh version.