### PR TITLE
fix: upgrade axios to 1.19.0 to address GHSA-gcfj-64vw-6mp9 and 9 related advisories

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,6 @@ workflows:
 
     - lumigo-orb/prep-it-resources:
         context: common
-        venv_python_version: "3.9"
         requires:
           - lumigo-orb/is_environment_available
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,10 @@ workflows:
 
     - lumigo-orb/prep-it-resources:
         context: common
+        # Must be >= 3.10: the orb installs pip==25.1 (needs >= 3.9) and
+        # pre-commit==4.6.0 (needs >= 3.10) into this venv. The image default
+        # python3 is 3.7, so this cannot be omitted.
+        venv_python_version: "3.11"
         requires:
           - lumigo-orb/is_environment_available
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3030,7 +3030,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "requires": {
         "debug": "4"
       }
@@ -3193,12 +3192,13 @@
       }
     },
     "axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "requires": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -5252,7 +5252,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@lumigo/node-core": "1.17.1",
     "agentkeepalive": "^4.1.4",
-    "axios": "^1.15.1",
+    "axios": "^1.19.0",
     "rfdc": "^1.4.1",
     "shimmer": "1.2.1",
     "utf8": "^3.0.0"

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -233,8 +233,10 @@ describe('utils', () => {
     expect(resultRoot).toEqual(patchedTraceIdPrefix);
     expect(resultSuffix).toEqual(patchedTraceIdSuffix);
 
+    // getPatchedTraceId truncates to whole seconds, so timeDiff is Date.now()
+    // modulo 1000 and is legitimately 0 on an exact second boundary
     const timeDiff = Date.now() - 1000 * parseInt(resultTime, 16);
-    expect(timeDiff).toBeGreaterThan(0);
+    expect(timeDiff).toBeGreaterThanOrEqual(0);
     expect(timeDiff).toBeLessThan(1500);
   });
 


### PR DESCRIPTION
## Changes proposed

The committed `package-lock.json` resolved **axios 1.16.0**, which is affected by 10 advisories — all first patched in **1.18.0**:

| Advisory | Severity | Affected |
|---|---|---|
| [GHSA-gcfj-64vw-6mp9](https://github.com/advisories/GHSA-gcfj-64vw-6mp9) — node HTTP adapter can use an inherited proxy after interceptor config cloning | **high** | `>=1.15.2 <1.18.0` |
| [GHSA-xj6q-8x83-jv6g](https://github.com/advisories/GHSA-xj6q-8x83-jv6g) — prototype pollution auth subfields can inject Basic auth | moderate | `>=1.15.2 <1.18.0` |
| [GHSA-hcpx-6fm6-wx23](https://github.com/advisories/GHSA-hcpx-6fm6-wx23) — form serializer `maxDepth` bypass via `{}` metatoken | moderate | `>=1.15.1 <1.18.0` |
| [GHSA-f4gw-2p7v-4548](https://github.com/advisories/GHSA-f4gw-2p7v-4548) — `NO_PROXY` bypass for `0.0.0.0` local addresses | moderate | `>=1.15.0 <1.18.0` |
| [GHSA-mwf2-3pr3-8698](https://github.com/advisories/GHSA-mwf2-3pr3-8698) — HTTP/2 streamed uploads bypass `maxBodyLength` | moderate | `>=1.13.0 <1.18.0` |
| [GHSA-jqh4-m9w3-8hp9](https://github.com/advisories/GHSA-jqh4-m9w3-8hp9) — fetch adapter `ReadableStream` uploads bypass `maxBodyLength` | moderate | `>=1.7.0 <1.18.0` |
| [GHSA-7q8q-rj6j-mhjq](https://github.com/advisories/GHSA-7q8q-rj6j-mhjq) — nested axios option objects can consume polluted prototype values | moderate | `>=1.0.0 <1.18.0` |
| [GHSA-mmx7-hfxf-jppx](https://github.com/advisories/GHSA-mmx7-hfxf-jppx) — prototype pollution gadgets can alter axios request construction | moderate | `>=1.0.0 <1.18.0` |
| [GHSA-42h9-826w-cgv3](https://github.com/advisories/GHSA-42h9-826w-cgv3) — excessive recursion in `formDataToJSON` can cause DoS | moderate | `>=1.0.0 <1.18.0` |
| [GHSA-pmv8-rq9r-6j72](https://github.com/advisories/GHSA-pmv8-rq9r-6j72) — deep `formToJSON` key recursion can cause DoS | moderate | `>=1.0.0 <1.18.0` |

### What changed

- `package.json`: `axios` `^1.15.1` → `^1.19.0`. Bumping to latest rather than the 1.18.0 floor means the declared range no longer *permits* a vulnerable version — relevant because consumers of `@lumigo/tracer` resolve axios themselves.
- `package-lock.json`: axios entry updated in place to 1.19.0 (new integrity hash, `form-data` floor `^4.0.6`, new `https-proxy-agent ^5.0.1`). Edited in place rather than regenerated so `lockfileVersion: 1` is preserved and the diff stays at 6 insertions / 7 deletions — a regenerated lock adds ~155 lines of unrelated churn.
- axios 1.18+ adds `https-proxy-agent` as a **production** dependency. It and its own dep `agent-base` were already in the lockfile as dev-only entries, so their `"dev": true` flag was dropped. `https-proxy-agent@5.0.1` carries no open advisories (those affect `<2.2.3`).

### Behavior note for reviewers

`src/httpSpansAgent.js` uses axios for a plain JSON POST with a custom keepalive agent and `maxRedirects: 0`, so the `maxBodyLength`, formData and redirect fixes are inert on this path. The one behavior change that could be observable is proxy resolution: 1.18.0 stops applying an inherited proxy after config cloning and tightens `NO_PROXY` handling for `0.0.0.0`, which may affect customers whose Lambdas reach the Lumigo edge through an env-configured proxy.

### Verification

- `npm ci --dry-run` → exactly one tree change (`axios 1.16.0 => 1.19.0`), nothing else moved
- `npm audit --omit=dev` → `found 0 vulnerabilities` (was 1 high + 9 moderate on axios)
- `npm run build` → clean
- `npm run jest` → **39/39 suites, 1779/1779 tests pass**. `axios-mock-adapter@1.21.2` works against axios 1.19 unchanged, so no dev-dep bump was needed.

Remaining `npm audit` findings are entirely in the dev tree (babel, eslint, semantic-release) and are out of scope here.

## Check List (Check all the boxes which are applicable)

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.