### PR TITLE
fix: classify account-based DynamoDB endpoints as dynamodb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,12 @@
 version: 2.1
 
 orbs:
-  lumigo-orb: &lumigo_orb_version lumigo/lumigo-orb@volatile
+  # Temporarily pinned to the dev build of
+  # https://github.com/lumigo-io/lumigo-orb/pull/241 so this branch can get past
+  # `pip install pre-commit==4.6.0`, which cannot resolve on this repo's venv python.
+  # Revert to `lumigo/lumigo-orb@volatile` once that PR is merged and promoted.
+  # (CircleCI deletes dev orb versions after 90 days.)
+  lumigo-orb: &lumigo_orb_version lumigo/lumigo-orb@dev:4cfb4a0
 
 defaults: &defaults
   docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,7 @@
 version: 2.1
 
 orbs:
-  # Temporarily pinned to the dev build of
-  # https://github.com/lumigo-io/lumigo-orb/pull/241 so this branch can get past
-  # `pip install pre-commit==4.6.0`, which cannot resolve on this repo's venv python.
-  # Revert to `lumigo/lumigo-orb@volatile` once that PR is merged and promoted.
-  # (CircleCI deletes dev orb versions after 90 days.)
-  lumigo-orb: &lumigo_orb_version lumigo/lumigo-orb@dev:4cfb4a0
+  lumigo-orb: &lumigo_orb_version lumigo/lumigo-orb@volatile
 
 defaults: &defaults
   docker:

--- a/src/spans/awsSpan.test.js
+++ b/src/spans/awsSpan.test.js
@@ -594,6 +594,12 @@ describe('awsSpan', () => {
     expect(awsSpan.getAwsServiceFromHost(host2)).toEqual(awsSpan.EXTERNAL_SERVICE);
   });
 
+  test('getAwsServiceFromHost -> account-based dynamodb endpoint', () => {
+    // Current AWS SDKs route DynamoDB to <account-id>.ddb.<region>.amazonaws.com
+    const host = '291070810472.ddb.us-west-2.amazonaws.com';
+    expect(awsSpan.getAwsServiceFromHost(host)).toEqual('dynamodb');
+  });
+
   test('getAwsServiceFromHost -> api-gw', () => {
     const host1 = `random.random.execute-api.amazonaws.com`;
     expect(awsSpan.getAwsServiceFromHost(host1)).toEqual('apigw');

--- a/src/spans/awsSpan.ts
+++ b/src/spans/awsSpan.ts
@@ -276,6 +276,12 @@ export const getAwsServiceFromHost = (host = '') => {
     return service;
   }
 
+  // Account-based DynamoDB endpoints put the account id in the first label:
+  // <account-id>.ddb.<region>.amazonaws.com. Current AWS SDKs route DynamoDB there
+  // by default (accountIdEndpointMode defaults to 'preferred'), so matching only the
+  // first label would classify the call as an external service.
+  if (host.split('.')[1] === 'ddb') return 'dynamodb';
+
   if (host.includes('execute-api')) return 'apigw';
 
   return EXTERNAL_SERVICE;


### PR DESCRIPTION
## What

`getAwsServiceFromHost` matches the **first** host label against `AWS_PARSED_SERVICES`, so account-based DynamoDB endpoints matched nothing:

| Host | Before | After |
|---|---|---|
| `<account-id>.ddb.<region>.amazonaws.com` | `external` | `dynamodb` |
| `dynamodb.<region>.amazonaws.com` | `dynamodb` | `dynamodb` |

Note the old result was `EXTERNAL_SERVICE`, not a generic AWS type — the call was reported as a **third-party host**, and `getServiceData` fell through to `defaultParser`, dropping the table name, `dynamodbMethod` and `messageId` that `dynamodbParser` contributes.

## Why

Current AWS SDKs route DynamoDB to the account-based endpoint by default: `accountIdEndpointMode` defaults to `preferred`.

Found while fixing the same gap on the Python side, where the backend classification (lumigo-io/python-common-utils#1781) and the tracer's own host-to-parser dispatch (lumigo-io/python_tracer#346) both missed this host shape. No Node integration test was failing — this is the equivalent fix so the Node tracer does not regress the same way.

## Testing

Added a case to the existing `getAwsServiceFromHost` describe block.

- `src/spans src/parsers src/utils.test.ts`: **112 passed**
- `tsc --noEmit`, `eslint`, `prettier --list-different`: all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)